### PR TITLE
Add static test scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.21.7@sha256:549dd88a1a53715f177b41ab5fee25f7a376a6bb5322ac7abe263480d9554021
+ARG BUILD_IMAGE=docker.io/golang:1.21.8@sha256:856073656d1a517517792e6cdd2f7a5ef080d3ca2dff33e518c8412f140fdd2d
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Ensure the go tool exists and is a viable version.
+verify_go_version()
+{
+    if [[ -z "$(command -v go)" ]]; then
+        cat << EOF
+Can't find 'go' in PATH, please fix and retry.
+See http://golang.org/doc/install for installation instructions.
+EOF
+        return 2
+    fi
+
+    local go_version
+    IFS=" " read -ra go_version <<< "$(go version)"
+    local minimum_go_version
+    minimum_go_version=go1.21
+    if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]] && [[ "${go_version[2]}" != "devel" ]]; then
+        cat << EOF
+Detected go version: ${go_version[*]}.
+Kubernetes requires ${minimum_go_version} or greater.
+Please install ${minimum_go_version} or later.
+EOF
+        return 2
+    fi
+}
+
+verify_go_version
+
+# Explicitly opt into go modules, even though we're inside a GOPATH directory
+export GO111MODULE=on

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# 1.  Verify that `go mod tidy` can be executed successfully
+# 2.  Verify that running the above doesn't change go.mod and go.sum
+#
+# NOTE: This won't work unless the build environment has internet access
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+    export XDG_CACHE_HOME=/tmp/.cache
+
+    mkdir /tmp/gomod
+    cp -r . /tmp/gomod
+    cd /tmp/gomod
+
+    STATUS="$(git status --porcelain)"
+    if [ -n "${STATUS}" ]; then
+        echo "Dirty tree: refusing to continue out of caution"
+        exit 1
+    fi
+
+    make modules
+
+    STATUS="$(git status --porcelain)"
+    if [ -n "${STATUS}" ]; then
+        echo "one of the go.mod and/or go.sum files changed"
+        echo "${STATUS}"
+        echo "Please run 'go mod tidy' and commit the changes"
+        exit 1
+    fi
+
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/golang:1.21 \
+        /workdir/hack/gomod.sh "$@"
+fi

--- a/hack/manifestlint.sh
+++ b/hack/manifestlint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+K8S_VERSION="${K8S_VERSION:-master}"
+
+# --strict: Disallow additional properties not in schema.
+# --ignore-missing-schemas: Skip validation for resource
+# definitions without a schema. This will skip the checks
+# for the Custom Resource Definitions(CRDs).
+# --ignore-filename-pattern string: ignore pattern, can give multiple
+# We are skipping validation for the files that
+# matches our regexp pattern (i.e. kustom, patch).
+# --output string: The format of the output of this script.
+# --kubernetes-version string: which k8s version schema to test against
+
+# KUBECONFORM_PATH is needed as kubeconform binary in the official image
+# is at the root /kubeconform, but it is not at default path, while
+# in non-container run, it is on go bin path and can't have leading /
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+    "${KUBECONFORM_PATH:-}"kubeconform --strict --ignore-missing-schemas \
+        --kubernetes-version "${K8S_VERSION}" \
+        --ignore-filename-pattern kustom --ignore-filename-pattern patch \
+        --ignore-filename-pattern clusterctl \
+        --output tap \
+        config/
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --env KUBECONFORM_PATH="/" \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740 \
+        /workdir/hack/manifestlint.sh "$@"
+fi

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# markdownlint-cli2 has config file(s) named .markdownlint-cli2.yaml in the repo
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+# all md files, but ignore .github
+if [ "${IS_CONTAINER}" != "false" ]; then
+    markdownlint-cli2 "**/*.md" "#.github"
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/pipelinecomponents/markdownlint-cli2:0.9.0@sha256:71370df6c967bae548b0bfd0ae313ddf44bfad87da76f88180eff55c6264098c \
+        /workdir/hack/markdownlint.sh "$@"
+fi


### PR DESCRIPTION
In order to prepare the repository for CI integration

This commit:
- Adds a subset of the static analysis and formatting tools.
- Modifies the root Makefile to allow running gomod.sh
- aligns static test container wrapper scripts

I will align the code and the docs in multiple PRs to not create xK line PRs.