### PR TITLE
Do not overwrite defaulted fields on the deployments

### DIFF
--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -85,7 +85,8 @@ func buildCommonEnvVars(ironic *metal3api.Ironic) []corev1.EnvVar {
 				Name: "PROVISIONING_IP",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "status.hostIP",
+						APIVersion: "v1",
+						FieldPath:  "status.hostIP",
 					},
 				},
 			},
@@ -225,7 +226,8 @@ func buildIronicVolumesAndMounts(ironic *metal3api.Ironic, db *metal3api.IronicD
 			Name: "ironic-auth",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: ironic.Spec.CredentialsRef.Name,
+					SecretName:  ironic.Spec.CredentialsRef.Name,
+					DefaultMode: ptr.To(corev1.SecretVolumeSourceDefaultMode),
 				},
 			},
 		},
@@ -249,7 +251,8 @@ func buildIronicVolumesAndMounts(ironic *metal3api.Ironic, db *metal3api.IronicD
 				Name: "cert-ironic",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: ironic.Spec.TLSRef.Name,
+						SecretName:  ironic.Spec.TLSRef.Name,
+						DefaultMode: ptr.To(corev1.SecretVolumeSourceDefaultMode),
 					},
 				},
 			},
@@ -277,7 +280,8 @@ func buildIronicVolumesAndMounts(ironic *metal3api.Ironic, db *metal3api.IronicD
 			Name: "cert-mariadb",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: db.Spec.TLSRef.Name,
+					SecretName:  db.Spec.TLSRef.Name,
+					DefaultMode: ptr.To(corev1.SecretVolumeSourceDefaultMode),
 				},
 			},
 		})
@@ -294,13 +298,17 @@ func buildIronicHttpdPorts(ironic *metal3api.Ironic) (ironicPorts []corev1.Conta
 	httpdPorts = []corev1.ContainerPort{
 		{
 			Name:          imagesPortName,
+			Protocol:      corev1.ProtocolTCP,
 			ContainerPort: ironic.Spec.Networking.ImageServerPort,
+			HostPort:      ironic.Spec.Networking.ImageServerPort,
 		},
 	}
 
 	apiPort := corev1.ContainerPort{
 		Name:          ironicPortName,
+		Protocol:      corev1.ProtocolTCP,
 		ContainerPort: ironic.Spec.Networking.APIPort,
+		HostPort:      ironic.Spec.Networking.APIPort,
 	}
 
 	if ironic.Spec.TLSRef.Name == "" {
@@ -310,7 +318,9 @@ func buildIronicHttpdPorts(ironic *metal3api.Ironic) (ironicPorts []corev1.Conta
 		if !ironic.Spec.DisableVirtualMediaTLS {
 			httpdPorts = append(httpdPorts, corev1.ContainerPort{
 				Name:          imagesTLSPortName,
+				Protocol:      corev1.ProtocolTCP,
 				ContainerPort: ironic.Spec.Networking.ImageServerTLSPort,
+				HostPort:      ironic.Spec.Networking.ImageServerTLSPort,
 			})
 		}
 	}

--- a/pkg/ironic/ironic.go
+++ b/pkg/ironic/ironic.go
@@ -35,12 +35,10 @@ func ensureIronicDaemonSet(cctx ControllerContext, ironic *metal3api.Ironic, db 
 	result, err := controllerutil.CreateOrUpdate(cctx.Context, cctx.Client, deploy, func() error {
 		if deploy.ObjectMeta.CreationTimestamp.IsZero() {
 			cctx.Logger.Info("creating a new ironic daemon set")
-			matchLabels := map[string]string{metal3api.IronicOperatorLabel: ironicDeploymentName(ironic)}
-			deploy.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: matchLabels,
-			}
 		}
-		deploy.Spec.Template = template
+		matchLabels := map[string]string{metal3api.IronicOperatorLabel: ironicDeploymentName(ironic)}
+		deploy.Spec.Selector = &metav1.LabelSelector{MatchLabels: matchLabels}
+		mergePodTemplates(&deploy.Spec.Template, template)
 		return controllerutil.SetControllerReference(ironic, deploy, cctx.Scheme)
 	})
 	if err != nil {
@@ -67,13 +65,11 @@ func ensureIronicDeployment(cctx ControllerContext, ironic *metal3api.Ironic, db
 	result, err := controllerutil.CreateOrUpdate(cctx.Context, cctx.Client, deploy, func() error {
 		if deploy.ObjectMeta.CreationTimestamp.IsZero() {
 			cctx.Logger.Info("creating a new ironic deployment")
-			matchLabels := map[string]string{metal3api.IronicOperatorLabel: ironicDeploymentName(ironic)}
-			deploy.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: matchLabels,
-			}
-			deploy.Spec.Replicas = ptr.To(int32(1))
 		}
-		deploy.Spec.Template = template
+		matchLabels := map[string]string{metal3api.IronicOperatorLabel: ironicDeploymentName(ironic)}
+		deploy.Spec.Selector = &metav1.LabelSelector{MatchLabels: matchLabels}
+		deploy.Spec.Replicas = ptr.To(int32(1))
+		mergePodTemplates(&deploy.Spec.Template, template)
 		// We cannot run two copies of Ironic in parallel
 		deploy.Spec.Strategy = appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,

--- a/test/functional.sh
+++ b/test/functional.sh
@@ -23,10 +23,15 @@ trap on_exit EXIT
 
 set -eu -o pipefail
 
+for image in ironic mariadb ironic-ipa-downloader; do
+    docker pull "quay.io/metal3-io/${image}"
+    kind load docker-image "quay.io/metal3-io/${image}"
+done
+
 make docker-build IMG="${IMG}"
 kind load docker-image "${IMG}"
 make install deploy IMG="${IMG}"
 
 kubectl wait --for=condition=Available --timeout=60s \
     -n ironic-standalone-operator-system deployment/ironic-standalone-operator-controller-manager
-cd test && go test
+cd test && go test -timeout 60m


### PR DESCRIPTION
Currently, the controllers are racing with the Deployment controller
over the fields with defaults (like ImagePullPolicy). Only modify
the fields we care about.

Finish the functional test to actually verify the deployment.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
