### PR TITLE
Simplify status conditions (fixes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,7 @@ Status:
     Observed Generation:   2
     Reason:                DeploymentAvailable
     Status:                True
-    Type:                  Available
-    Last Transition Time:  2023-08-25T13:05:35Z
-    Message:               ironic is available
-    Observed Generation:   2
-    Reason:                DeploymentAvailable
-    Status:                False
-    Type:                  Progressing
+    Type:                  Ready
 ```
 
 Now you can see the service that can be used to access Ironic (it has the same

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -3,11 +3,12 @@ package v1alpha1
 type IronicStatusConditionType string
 
 const (
-	// Available indicates that Ironic is fully available
-	IronicStatusAvailable IronicStatusConditionType = "Available"
+	// Ready indicates that Ironic is fully available.
+	IronicStatusReady IronicStatusConditionType = "Ready"
 
-	// Progressing indicates that Ironic deployment is in progress
-	IronicStatusProgressing IronicStatusConditionType = "Progressing"
+	IronicReasonFailed     = "DeploymentFailed"
+	IronicReasonInProgress = "DeploymentInProgress"
+	IronicReasonAvailable  = "DeploymentAvailable"
 
 	IronicOperatorLabel = "metal3.io/ironic-standalone-operator"
 )

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -93,7 +93,7 @@ func WaitForIronic(name types.NamespacedName) *metal3api.Ironic {
 		err := k8sClient.Get(ctx, name, ironic)
 		Expect(err).NotTo(HaveOccurred())
 
-		cond := meta.FindStatusCondition(ironic.Status.Conditions, string(metal3api.IronicStatusAvailable))
+		cond := meta.FindStatusCondition(ironic.Status.Conditions, string(metal3api.IronicStatusReady))
 		if cond != nil && cond.Status == metav1.ConditionTrue {
 			return true
 		}


### PR DESCRIPTION
Ready seems to be the most commonly used name. Progressing may not be
the most useful, so drop it for now. Refactor the code to use simple
booleans.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
