### PR TITLE
 Modify the "Error info" when ironic is deployed in distributed architecture

### DIFF
--- a/pkg/ironic/ironic.go
+++ b/pkg/ironic/ironic.go
@@ -143,7 +143,7 @@ func EnsureIronic(cctx ControllerContext, ironic *metal3api.Ironic, db *metal3ap
 
 	if ironic.Spec.Distributed {
 		if db == nil {
-			return false, errors.New("database is required for a distributed deployment")
+			return false, errors.New("database is required for distributed architecture")
 		}
 
 		err = removeIronicDeployment(cctx, ironic)


### PR DESCRIPTION
 Modify the "Error info" when ironic is deployed in distributed architecture
