### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,8 @@
-# See the OWNERS docs at https://go.k8s.io/owners
+# See the OWNERS docs at <https://go.k8s.io/owners>
 
 approvers:
- - dtantsur
+- ironic-standalone-operator-maintainers
 
 reviewers:
- - elfosardo
- - lentzi90
- - Rozzii
+- ironic-standalone-operator-maintainers
+- ironic-standalone-operator-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,10 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  ironic-standalone-operator-maintainers:
+  - dtantsur
+
+  ironic-standalone-operator-reviewers:
+  - elfosardo
+  - lentzi90
+  - Rozzii


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.