### PR TITLE
explicitly drop pr approver workflow permissions

### DIFF
--- a/.github/workflows/pr-gh-workflow-approve.yaml
+++ b/.github/workflows/pr-gh-workflow-approve.yaml
@@ -8,6 +8,8 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
+permissions: {}
+
 jobs:
   approve:
     name: Approve on ok-to-test


### PR DESCRIPTION
Drop all permissions on top-level. We're already giving out actions: write on the job level.

This is noted in the OpenSSF scorecard as well.