### PR TITLE
Determine whether initcontainer is needed through IPAConfig options

### DIFF
--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -144,6 +144,11 @@ type Images struct {
 	// +kubebuilder:default=quay.io/metal3-io/ironic-ipa-downloader
 	// +optional
 	RamdiskDownloader string `json:"ramdiskDownloader,omitempty"`
+
+	// DisableRamdiskDownloader turns off the ramdisk downloader.
+	// +kubebuilder:default=false
+	// +optional
+	DisableRamdiskDownloader bool `json:"disableRamdiskDownloader,omitempty"`
 }
 
 // IronicSpec defines the desired state of Ironic

--- a/api/v1alpha1/ironic_webhook.go
+++ b/api/v1alpha1/ironic_webhook.go
@@ -203,7 +203,7 @@ func validateIronic(ironic *IronicSpec, old *IronicSpec) error {
 		}
 	}
 
-	if ironic.Images.AgentDownloadURL != "" {
+	if !ironic.Images.DisableRamdiskDownloader && ironic.Images.AgentDownloadURL != "" {
 		if _, err := url.Parse(ironic.Images.AgentDownloadURL); err != nil {
 			return fmt.Errorf("images.agentDownloadURL is not a valid URL: %w", err)
 		}

--- a/config/crd/bases/metal3.io_ironics.yaml
+++ b/config/crd/bases/metal3.io_ironics.yaml
@@ -105,6 +105,10 @@ spec:
                       AgentDownloadURL is the base URL from which IPA should be downloaded.
                       The default value should be good for most users.
                     type: string
+                  disableRamdiskDownloader:
+                    default: false
+                    description: DisableRamdiskDownloader turns off the ramdisk downloader.
+                    type: boolean
                   ironic:
                     default: quay.io/metal3-io/ironic
                     description: Ironic is the Ironic image (including httpd).


### PR DESCRIPTION
Some times we can build a http server out of cluster and we can also ues it to be as a image-server. And we can upload kernal and ramdisk into it. So I think we may don't need the init-Pod in Ironic's Pod.

I have modified the Ironic CRD

```yaml
apiVersion: metal3.io/v1alpha1
kind: Ironic
metadata:
  name: ironic-server
spec:
  images:
    ipaConfig:
      ipaEnabled: true
      ironic: registry.paas/metal3-io/ironic:v1.0
      ramdiskDownloader: registry.paas/metal3-io/ipa-config:v17
```