### PR TITLE
Fix bug for supporting nodeselector (closes #48)

### DIFF
--- a/pkg/ironic/utils.go
+++ b/pkg/ironic/utils.go
@@ -89,6 +89,9 @@ func mergePodTemplates(target *corev1.PodTemplateSpec, source corev1.PodTemplate
 	if source.Spec.DNSPolicy != "" {
 		target.Spec.DNSPolicy = source.Spec.DNSPolicy
 	}
+	if source.Spec.NodeSelector != nil {
+		target.Spec.NodeSelector = source.Spec.NodeSelector
+	}
 }
 
 func getDeploymentStatus(cctx ControllerContext, deploy *appsv1.Deployment) (bool, error) {


### PR DESCRIPTION
the `func mergePodTemplates(target *corev1.PodTemplateSpec, source corev1.PodTemplateSpec)`  lacks handling of nodeselector.

this pr want to solve the #48