### PR TITLE
:seedling: Add wf to automatically build controller image

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -1,0 +1,25 @@
+name: build-images-action
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+    - 'main'
+    - 'release-*'
+    tags:
+    - 'v*'
+
+jobs:
+  build_controller:
+    name: Build Ironic-standalone-operator container image
+    if: github.repository == 'metal3-io/ironic-standalone-operator'
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    with:
+      image-name: 'ironic-standalone-operator'
+      pushImage: true
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
This PR adds support for automatic container image build. Whenever a new PR is merged into `main` or one of the release branches, and whenever a new `v*` tag is created, a new container image is built and pushed to `quay.io/metal3-io`, with suitable tags applied.