### PR TITLE
Clean-up configuration manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= quay.io/metal3-io/ironic-standalone-operator:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -82,6 +82,8 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 RUNARGS ?=
+
+DEPLOY_TARGET ?= default
 
 .PHONY: all
 all: build
@@ -189,11 +191,11 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/$(DEPLOY_TARGET) | kubectl apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/$(DEPLOY_TARGET) | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Build Dependencies
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,17 +6,13 @@ resources:
 - bases/metal3.io_ironicdatabases.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
-# patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_ironics.yaml
-#- patches/webhook_in_ironicdatabases.yaml
+patches:
+- path: patches/webhook_in_ironics.yaml
+- path: patches/webhook_in_ironicdatabases.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
-# patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_ironics.yaml
-#- patches/cainjection_in_ironicdatabases.yaml
+- path: patches/cainjection_in_ironics.yaml
+- path: patches/cainjection_in_ironicdatabases.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,72 +1,50 @@
 # Adds namespace to all resources.
 namespace: ironic-standalone-operator-system
-
-# Value of this field is prepended to the
-# names of all resources, e.g. a deployment named
-# "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
 namePrefix: ironic-standalone-operator-
 
-# Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
-
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../webhook
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
-
-
-
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- manager_webhook_patch.yaml
-
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
-# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+- path: manager_auth_proxy_patch.yaml
+- path: manager_webhook_patch.yaml
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- path: webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -53,4 +53,3 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
-        - "--webhook-port=0"  # FIXME(dtantsur): set up TLS and enable

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,9 +41,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        - --webhook-port 0  # FIXME(dtantsur): set up TLS and enable
-        # TODO(dtantsur): default to a published image
-        image: controller:latest
+        image: quay.io/metal3-io/ironic-standalone-operator:latest
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/testing/kustomization.yaml
+++ b/config/testing/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- ../default
+
+patches:
+- path: manager_feature_gates_patch.yaml

--- a/config/testing/manager_feature_gates_patch.yaml
+++ b/config/testing/manager_feature_gates_patch.yaml
@@ -7,4 +7,7 @@ spec:
   template:
     spec:
       containers:
-      - name: manager
+        - name: manager
+          env:
+            - name: FEATURE_GATES
+              value: HighAvailability=true

--- a/test/prepare.sh
+++ b/test/prepare.sh
@@ -5,20 +5,31 @@ set -eux -o pipefail
 IMG="${IMG:-localhost/controller:test}"
 LOGDIR="${LOGDIR:-/tmp/logs}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-}"
+CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-1.16.1}"
 
 mkdir -p "${LOGDIR}"
 
-if [ -z "${CONTAINER_RUNTIME}" ]; then
-    if podman version > /dev/null 2>&1;  then
+if [[ -z "${CONTAINER_RUNTIME}" ]]; then
+    if command -v podman &> /dev/null;  then
         CONTAINER_RUNTIME=podman
     else
         CONTAINER_RUNTIME=docker
     fi
 fi
 
+# Installing cert-manager
+
+kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml"
+kubectl wait --for=condition=Available --timeout=60s \
+    -n cert-manager deployment/cert-manager
+kubectl wait --for=condition=Available --timeout=60s \
+    -n cert-manager deployment/cert-manager-webhook
+
+# Caching required images
+
 kind_load() {
     local image="$1"
-    if [ "${CONTAINER_RUNTIME}" = podman ]; then
+    if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
         local archive="$(mktemp --suffix=.tar)"
         podman save "${image}" > "${archive}"
         kind load image-archive -v 2 "${archive}"
@@ -33,9 +44,11 @@ for image in ironic mariadb ironic-ipa-downloader; do
     kind_load "quay.io/metal3-io/${image}"
 done
 
+# Building and installing the operator
+
 "${CONTAINER_RUNTIME}" build -t "${IMG}" . 2>&1 | tee "${LOGDIR}/docker-build.log"
 kind_load "${IMG}"
-make install deploy IMG="${IMG}"
+make install deploy IMG="${IMG}" DEPLOY_TARGET=testing
 
 kubectl wait --for=condition=Available --timeout=60s \
     -n ironic-standalone-operator-system deployment/ironic-standalone-operator-controller-manager


### PR DESCRIPTION
- Use the published image by default
- Enable cert-manager support by default
- Re-enable the webhook port and webhook manifests
- Add a testing overlay to enable all feature gates
- Fix deprecation warnings in kustomizations

Closes: #29 