### PR TITLE
Add an environment file and a configmap to customize the manager

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - manager.yaml
+
+configMapGenerator:
+- envs:
+  - manager.env
+  name: ironic-standalone-operator-config

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,6 +41,9 @@ spec:
         - /manager
         args:
         - --leader-elect
+        envFrom:
+        - configMapRef:
+            name: ironic-standalone-operator-config
         image: quay.io/metal3-io/ironic-standalone-operator:latest
         name: manager
         securityContext:


### PR DESCRIPTION
Doing so simplifies downstream customizations, e.g. in metal3-dev-env:
https://github.com/metal3-io/metal3-dev-env/pull/1466.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
