### PR TITLE
✨ Rework reporting status to the controller

### DIFF
--- a/api/v1alpha1/ironic_webhook.go
+++ b/api/v1alpha1/ironic_webhook.go
@@ -86,13 +86,13 @@ var _ webhook.Validator = &Ironic{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Ironic) ValidateCreate() (warnings admission.Warnings, err error) {
 	ironiclog.Info("validate create", "name", r.Name)
-	return nil, validateIronic(&r.Spec, nil)
+	return nil, ValidateIronic(&r.Spec, nil)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Ironic) ValidateUpdate(old runtime.Object) (warnings admission.Warnings, err error) {
 	ironiclog.Info("validate update", "name", r.Name)
-	return nil, validateIronic(&r.Spec, &old.(*Ironic).Spec)
+	return nil, ValidateIronic(&r.Spec, &old.(*Ironic).Spec)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
@@ -178,7 +178,7 @@ func ValidateDHCP(ironic *IronicSpec, dhcp *DHCP) error {
 	return nil
 }
 
-func validateIronic(ironic *IronicSpec, old *IronicSpec) error {
+func ValidateIronic(ironic *IronicSpec, old *IronicSpec) error {
 	if ironic.HighAvailability && ironic.DatabaseRef.Name == "" {
 		return errors.New("database is required for highly available architecture")
 	}

--- a/api/v1alpha1/ironic_webhook_test.go
+++ b/api/v1alpha1/ironic_webhook_test.go
@@ -135,7 +135,7 @@ func TestValidateIronic(t *testing.T) {
 				tc.OldIronic = &tc.Ironic
 			}
 
-			err := validateIronic(&tc.Ironic, tc.OldIronic)
+			err := ValidateIronic(&tc.Ironic, tc.OldIronic)
 			if tc.ExpectedError == "" {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/ironic/status.go
+++ b/pkg/ironic/status.go
@@ -1,0 +1,55 @@
+package ironic
+
+type Status struct {
+	// Object is reconciled but some resources may be in progress.
+	Reconciled bool
+	// Object is reconciled and all resources are ready.
+	Ready bool
+	// Fatal error, further reconciliation is not possible.
+	Fatal error
+}
+
+func (status Status) IsError() bool {
+	return status.Fatal != nil
+}
+
+func (status Status) IsReady() bool {
+	return status.Ready && !status.IsError()
+}
+
+func (status Status) String() string {
+	if status.Fatal != nil {
+		return status.Fatal.Error()
+	}
+
+	if !status.Reconciled {
+		return "resources are being updated"
+	}
+
+	if !status.Ready {
+		return "resources are not ready yet"
+	}
+
+	return "resources are available"
+}
+
+// Everything is done, no more reconciliation required.
+func ready() (Status, error) {
+	return Status{Reconciled: true, Ready: true}, nil
+}
+
+// We have updated dependent resources.
+func updated() (Status, error) {
+	return Status{}, nil
+}
+
+// We are passively waiting for something external to happen.
+func inProgress() (Status, error) {
+	return Status{Reconciled: true}, nil
+}
+
+// Checking or updating status failed, we hope it's going to resolve itself
+// (e.g. a glitch in access to Kube API).
+func transientError(err error) (Status, error) {
+	return Status{}, err
+}


### PR DESCRIPTION
Currently, the reconciliation code does not distinguish between
potentially transient errors and fatal validation errors (which cannot
be resolved without an update of the resource).

This PR adds a Status object that is loosely modelled after the
provisioner's Result in BMO. More helpers are added to avoid repetition.

As a bonus, we now distinguish between two states: resources are being
updated and we are waiting for resources to get ready.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
