### PR TITLE
🐛 Fix invalid names for webhooks

### DIFF
--- a/api/v1alpha1/ironic_webhook.go
+++ b/api/v1alpha1/ironic_webhook.go
@@ -38,7 +38,7 @@ func (r *Ironic) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-metal3-io-v1alpha1-ironic,mutating=true,failurePolicy=fail,sideEffects=None,groups=metal3.io,resources=ironics,verbs=create;update,versions=v1alpha1,name=mironic.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/mutate-metal3-io-v1alpha1-ironic,mutating=true,failurePolicy=fail,sideEffects=None,groups=metal3.io,resources=ironics,verbs=create;update,versions=v1alpha1,name=mutate-ironic.metal3.io,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &Ironic{}
 
@@ -79,7 +79,7 @@ func setDefaults(ironic *IronicSpec) {
 	}
 }
 
-//+kubebuilder:webhook:path=/validate-metal3-io-v1alpha1-ironic,mutating=false,failurePolicy=fail,sideEffects=None,groups=metal3.io,resources=ironics,verbs=create;update,versions=v1alpha1,name=vironic.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-metal3-io-v1alpha1-ironic,mutating=false,failurePolicy=fail,sideEffects=None,groups=metal3.io,resources=ironics,verbs=create;update,versions=v1alpha1,name=validate-ironic.metal3.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &Ironic{}
 

--- a/api/v1alpha1/ironicdatabase_webhook.go
+++ b/api/v1alpha1/ironicdatabase_webhook.go
@@ -33,15 +33,14 @@ func (r *IronicDatabase) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-metal3-io-v1alpha1-ironicdatabase,mutating=true,failurePolicy=fail,sideEffects=None,groups=metal3.io,resources=ironicdatabases,verbs=create;update,versions=v1alpha1,name=mironicdatabase.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/mutate-metal3-io-v1alpha1-ironicdatabase,mutating=true,failurePolicy=fail,sideEffects=None,groups=metal3.io,resources=ironicdatabases,verbs=create;update,versions=v1alpha1,name=mutate-ironicdatabase.metal3.io,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &IronicDatabase{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *IronicDatabase) Default() {}
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/validate-metal3-io-v1alpha1-ironicdatabase,mutating=false,failurePolicy=fail,sideEffects=None,groups=metal3.io,resources=ironicdatabases,verbs=create;update,versions=v1alpha1,name=vironicdatabase.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-metal3-io-v1alpha1-ironicdatabase,mutating=false,failurePolicy=fail,sideEffects=None,groups=metal3.io,resources=ironicdatabases,verbs=create;update,versions=v1alpha1,name=validate-ironicdatabase.metal3.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &IronicDatabase{}
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -12,7 +12,7 @@ webhooks:
       namespace: system
       path: /mutate-metal3-io-v1alpha1-ironic
   failurePolicy: Fail
-  name: mironic.kb.io
+  name: mutate-ironic.metal3.io
   rules:
   - apiGroups:
     - metal3.io
@@ -32,7 +32,7 @@ webhooks:
       namespace: system
       path: /mutate-metal3-io-v1alpha1-ironicdatabase
   failurePolicy: Fail
-  name: mironicdatabase.kb.io
+  name: mutate-ironicdatabase.metal3.io
   rules:
   - apiGroups:
     - metal3.io
@@ -58,7 +58,7 @@ webhooks:
       namespace: system
       path: /validate-metal3-io-v1alpha1-ironic
   failurePolicy: Fail
-  name: vironic.kb.io
+  name: validate-ironic.metal3.io
   rules:
   - apiGroups:
     - metal3.io
@@ -78,7 +78,7 @@ webhooks:
       namespace: system
       path: /validate-metal3-io-v1alpha1-ironicdatabase
   failurePolicy: Fail
-  name: vironicdatabase.kb.io
+  name: validate-ironicdatabase.metal3.io
   rules:
   - apiGroups:
     - metal3.io


### PR DESCRIPTION
I have no idea what kb.io is, or why the webhooks got generated this
way. Fix to provide reasonable names.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
