### PR TITLE
✨ Add basic support for Keepalived

### DIFF
--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -75,6 +75,13 @@ type DHCP struct {
 	ServeDNS bool `json:"serveDNS,omitempty"`
 }
 
+type IPAddressManager string
+
+const (
+	IPAddressManagerNone       IPAddressManager = ""
+	IPAddressManagerKeepalived IPAddressManager = "keepalived"
+)
+
 // Networking defines networking settings for Ironic
 type Networking struct {
 	// APIPort is the public port used for Ironic.
@@ -117,6 +124,14 @@ type Networking struct {
 	// Detected from Interface if missing. Cannot be provided for a highly available architecture.
 	// +optional
 	IPAddress string `json:"ipAddress,omitempty"`
+
+	// Configures the way the provided IP address will be managed on the provided interface.
+	// By default, the IP address is expected to be already present.
+	// Use "keepalived" to start a Keepalived container managing the IP address.
+	// Warning: keepalived is not compatible with the highly available architecture.
+	// +kubebuilder:validation:Enum="";keepalived
+	// +optional
+	IPAddressManager IPAddressManager `json:"ipAddressManager,omitempty"`
 
 	// MACAddresses can be provided to make the start script pick the interface matching any of these addresses.
 	// Only set if no other options can be used.

--- a/api/v1alpha1/ironic_webhook.go
+++ b/api/v1alpha1/ironic_webhook.go
@@ -205,6 +205,15 @@ func ValidateIronic(ironic *IronicSpec, old *IronicSpec) error {
 		}
 	}
 
+	if ironic.Networking.IPAddressManager == IPAddressManagerKeepalived {
+		if ironic.HighAvailability {
+			return errors.New("networking: keepalived is not compatible with the highly available architecture")
+		}
+		if ironic.Networking.IPAddress == "" || ironic.Networking.Interface == "" {
+			return errors.New("networking: keepalived requires specifying both ipAddress and interface")
+		}
+	}
+
 	if ironic.HighAvailability && !CurrentFeatureGate.Enabled(FeatureHighAvailability) {
 		return errors.New("highly available architecture is disabled via feature gate")
 	}

--- a/api/v1alpha1/ironic_webhook_test.go
+++ b/api/v1alpha1/ironic_webhook_test.go
@@ -127,6 +127,68 @@ func TestValidateIronic(t *testing.T) {
 			},
 			ExpectedError: "highly available architecture is disabled",
 		},
+		{
+			Scenario: "With Keepalived, no DHCP",
+			Ironic: IronicSpec{
+				Networking: Networking{
+					Interface:        "eth0",
+					IPAddress:        "192.0.2.2",
+					IPAddressManager: IPAddressManagerKeepalived,
+				},
+			},
+		},
+		{
+			Scenario: "With Keepalived and DHCP",
+			Ironic: IronicSpec{
+				Networking: Networking{
+					DHCP: &DHCP{
+						NetworkCIDR: "192.0.2.1/24",
+						RangeBegin:  "192.0.2.10",
+						RangeEnd:    "192.0.2.200",
+					},
+					Interface:        "eth0",
+					IPAddress:        "192.0.2.2",
+					IPAddressManager: IPAddressManagerKeepalived,
+				},
+			},
+		},
+		{
+			Scenario: "Keepalived requires Interface",
+			Ironic: IronicSpec{
+				Networking: Networking{
+					IPAddress:        "192.0.2.2",
+					IPAddressManager: IPAddressManagerKeepalived,
+				},
+			},
+			ExpectedError: "keepalived requires specifying both ipAddress and interface",
+		},
+		{
+			Scenario: "Keepalived requires IPAddress",
+			Ironic: IronicSpec{
+				Networking: Networking{
+					Interface:        "eth0",
+					IPAddressManager: IPAddressManagerKeepalived,
+				},
+			},
+			ExpectedError: "keepalived requires specifying both ipAddress and interface",
+		},
+		{
+			Scenario: "Keepalived exclusive with HA",
+			Ironic: IronicSpec{
+				DatabaseRef: corev1.LocalObjectReference{
+					Name: "db",
+				},
+				HighAvailability: true,
+				Networking: Networking{
+					Interface:        "eth0",
+					IPAddress:        "192.0.2.2",
+					IPAddressManager: IPAddressManagerKeepalived,
+				},
+			},
+			// NOTE(dtantsur): the expected error here is shadowed by the prior validation.
+			// I'm keeping this test in place to ensure that *some* validation failure happens.
+			ExpectedError: "ipAddress makes no sense with highly available architecture",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/config/crd/bases/metal3.io_ironics.yaml
+++ b/config/crd/bases/metal3.io_ironics.yaml
@@ -202,6 +202,16 @@ spec:
                       IPAddress is the main IP address to listen on and use for communication.
                       Detected from Interface if missing. Cannot be provided for a highly available architecture.
                     type: string
+                  ipAddressManager:
+                    description: |-
+                      Configures the way the provided IP address will be managed on the provided interface.
+                      By default, the IP address is expected to be already present.
+                      Use "keepalived" to start a Keepalived container managing the IP address.
+                      Warning: keepalived is not compatible with the highly available architecture.
+                    enum:
+                    - ""
+                    - keepalived
+                    type: string
                   macAddresses:
                     description: |-
                       MACAddresses can be provided to make the start script pick the interface matching any of these addresses.

--- a/main.go
+++ b/main.go
@@ -118,6 +118,8 @@ func main() {
 		"MariaDB image to install.")
 	flag.StringVar(&versionInfo.RamdiskDownloaderImage, "ramdisk-downloader-image", os.Getenv("RAMDISK_DOWNLOADER_IMAGE"),
 		"Ramdisk downloader image to install.")
+	flag.StringVar(&versionInfo.KeepalivedImage, "keepalived-image", os.Getenv("KEEPALIVED_IMAGE"),
+		"Keepalived image to install.")
 	flag.StringVar(&versionInfo.InstalledVersion, "ironic-version", os.Getenv("IRONIC_VERSION"),
 		"Branch of Ironic that the operator installs.")
 

--- a/pkg/ironic/containers_test.go
+++ b/pkg/ironic/containers_test.go
@@ -1,0 +1,86 @@
+package ironic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
+)
+
+func TestExpectedContainers(t *testing.T) {
+	testCases := []struct {
+		Scenario string
+
+		Ironic metal3api.IronicSpec
+
+		ExpectedContainerNames []string
+		ExpectedError          string
+	}{
+		{
+			Scenario:               "empty",
+			ExpectedContainerNames: []string{"httpd", "ironic", "ramdisk-logs"},
+		},
+		{
+			Scenario: "Keepalived",
+			Ironic: metal3api.IronicSpec{
+				Networking: metal3api.Networking{
+					Interface:        "eth0",
+					IPAddress:        "192.0.2.2",
+					IPAddressManager: metal3api.IPAddressManagerKeepalived,
+				},
+			},
+			ExpectedContainerNames: []string{"httpd", "ironic", "keepalived", "ramdisk-logs"},
+		},
+		{
+			Scenario: "Keepalived and DHCP",
+			Ironic: metal3api.IronicSpec{
+				Networking: metal3api.Networking{
+					DHCP: &metal3api.DHCP{
+						NetworkCIDR: "192.0.2.1/24",
+						RangeBegin:  "192.0.2.10",
+						RangeEnd:    "192.0.2.200",
+					},
+					Interface:        "eth0",
+					IPAddress:        "192.0.2.2",
+					IPAddressManager: metal3api.IPAddressManagerKeepalived,
+				},
+			},
+			ExpectedContainerNames: []string{"dnsmasq", "httpd", "ironic", "keepalived", "ramdisk-logs"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			cctx := ControllerContext{}
+			secret := &corev1.Secret{
+				Data: map[string][]byte{
+					"htpasswd": []byte("abcd"),
+				},
+			}
+			ironic := &metal3api.Ironic{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+				Spec: tc.Ironic,
+			}
+
+			podTemplate, err := newIronicPodTemplate(cctx, ironic, nil, secret, "test-domain.example.com")
+			if tc.ExpectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.ExpectedError)
+			}
+
+			var containerNames []string
+			for _, cont := range podTemplate.Spec.Containers {
+				containerNames = append(containerNames, cont.Name)
+			}
+
+			assert.ElementsMatch(t, tc.ExpectedContainerNames, containerNames)
+		})
+	}
+}

--- a/pkg/ironic/version.go
+++ b/pkg/ironic/version.go
@@ -9,6 +9,7 @@ var (
 	defaultIronicImage            = defaultRegistry + "ironic:" + installedVersion
 	defaultMariaDBImage           = defaultRegistry + "mariadb:latest"
 	defaultRamdiskDownloaderImage = defaultRegistry + "ironic-ipa-downloader:latest"
+	defaultKeepalivedImage        = defaultRegistry + "keepalived:latest"
 )
 
 type VersionInfo struct {
@@ -18,6 +19,7 @@ type VersionInfo struct {
 	RamdiskDownloaderImage string
 	AgentBranch            string
 	AgentDownloadURL       string
+	KeepalivedImage        string
 }
 
 func VersionInfoWithDefaults(versionInfo VersionInfo) VersionInfo {
@@ -32,6 +34,9 @@ func VersionInfoWithDefaults(versionInfo VersionInfo) VersionInfo {
 	}
 	if versionInfo.RamdiskDownloaderImage == "" {
 		versionInfo.RamdiskDownloaderImage = defaultRamdiskDownloaderImage
+	}
+	if versionInfo.KeepalivedImage == "" {
+		versionInfo.KeepalivedImage = defaultKeepalivedImage
 	}
 	return versionInfo
 }


### PR DESCRIPTION
This commit adds a new flag to the Networking structure to enable
keepalived (to accommodate potential future changes, it is designed as
an enum, not as a boolean).

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
