### PR TITLE
🌱 CI: run `apt update` before installing podman

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Update repositories
+      run: sudo apt update
     - name: Install podman
       run: sudo apt install -y podman
     - name: Build the image


### PR DESCRIPTION
Right now, the job fails on a stale package.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
