### PR TITLE
🐛 Fix image override in the Makefile, collect more logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image quay.io/metal3-io/ironic-standalone-operator=${IMG}
 	$(KUSTOMIZE) build config/$(DEPLOY_TARGET) | kubectl apply -f -
 
 .PHONY: undeploy

--- a/test/collect-logs.sh
+++ b/test/collect-logs.sh
@@ -4,8 +4,13 @@ set -ux
 
 LOGDIR="${LOGDIR:-/tmp/logs}"
 
-mkdir -p "${LOGDIR}"
+mkdir -p "${LOGDIR}/controller/"
 
+kubectl get -o yaml \
+    -n ironic-standalone-operator-system deployment/ironic-standalone-operator-controller-manager \
+    > "${LOGDIR}/controller/deployment.yaml"
+kubectl get pod -o yaml \
+    -n ironic-standalone-operator-system > "${LOGDIR}/controller/pods.yaml"
 kubectl logs \
     -n ironic-standalone-operator-system deployment/ironic-standalone-operator-controller-manager \
-    > "${LOGDIR}/controller.log"
+    > "${LOGDIR}/controller/manager.log"

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -113,6 +113,8 @@ func WaitForIronic(name types.NamespacedName) *metal3api.Ironic {
 		err := k8sClient.Get(ctx, name, ironic)
 		Expect(err).NotTo(HaveOccurred())
 
+		writeYAML(ironic, ironic.Namespace, ironic.Name, "ironic")
+
 		cond := meta.FindStatusCondition(ironic.Status.Conditions, string(metal3api.IronicStatusReady))
 		if cond != nil && cond.Status == metav1.ConditionTrue {
 			Expect(ironic.Status.InstalledVersion).ToNot(BeNil())
@@ -125,6 +127,7 @@ func WaitForIronic(name types.NamespacedName) *metal3api.Ironic {
 			deploy, err := clientset.AppsV1().DaemonSets(name.Namespace).Get(ctx, deployName, metav1.GetOptions{})
 			if err == nil {
 				GinkgoWriter.Printf(".. status of daemon set: %+v\n", deploy.Status)
+				writeYAML(deploy, deploy.Namespace, deploy.Name, "daemonset")
 			} else if !k8serrors.IsNotFound(err) {
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -132,6 +135,7 @@ func WaitForIronic(name types.NamespacedName) *metal3api.Ironic {
 			deploy, err := clientset.AppsV1().Deployments(name.Namespace).Get(ctx, deployName, metav1.GetOptions{})
 			if err == nil {
 				GinkgoWriter.Printf(".. status of deployment: %+v\n", deploy.Status)
+				writeYAML(deploy, deploy.Namespace, deploy.Name, "deployment")
 			} else if !k8serrors.IsNotFound(err) {
 				Expect(err).NotTo(HaveOccurred())
 			}


### PR DESCRIPTION
Currently, it overrides a non-existing image location.

Update log collection with information I used to debug this:

Make sure the Ironic resource is collected even if it never finishes
provisioning. Also collect Deployment/DaemonSet. Collect the manager's
deployment and pods in the end of a run.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
