### PR TITLE
🌱 Label pods/deployments with a version and clean up selector labels

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -10,5 +10,11 @@ const (
 	IronicReasonInProgress = "DeploymentInProgress"
 	IronicReasonAvailable  = "DeploymentAvailable"
 
-	IronicOperatorLabel = "metal3.io/ironic-standalone-operator"
+	IronicLabelPrefix = "ironic.metal3.io"
+)
+
+var (
+	IronicAppLabel      = IronicLabelPrefix + "/app"
+	IronicDatabaseLabel = IronicLabelPrefix + "/db"
+	IronicVersionLabel  = IronicLabelPrefix + "/version"
 )

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -572,7 +572,10 @@ func newIronicPodTemplate(cctx ControllerContext, ironic *metal3api.Ironic, db *
 
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{metal3api.IronicOperatorLabel: ironicDeploymentName(ironic)},
+			Labels: map[string]string{
+				metal3api.IronicAppLabel:     ironicDeploymentName(ironic),
+				metal3api.IronicVersionLabel: cctx.VersionInfo.InstalledVersion,
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers:     containers,

--- a/pkg/ironic/database.go
+++ b/pkg/ironic/database.go
@@ -124,7 +124,7 @@ func newDatabasePodTemplate(db *metal3api.IronicDatabase, versionInfo VersionInf
 
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{metal3api.IronicOperatorLabel: databaseDeploymentName(db)},
+			Labels: map[string]string{metal3api.IronicDatabaseLabel: databaseDeploymentName(db)},
 		},
 		Spec: corev1.PodSpec{
 			Containers: containers,
@@ -141,7 +141,7 @@ func ensureDatabaseDeployment(cctx ControllerContext, db *metal3api.IronicDataba
 		if deploy.ObjectMeta.CreationTimestamp.IsZero() {
 			cctx.Logger.Info("creating a new deployment")
 		}
-		matchLabels := map[string]string{metal3api.IronicOperatorLabel: databaseDeploymentName(db)}
+		matchLabels := map[string]string{metal3api.IronicDatabaseLabel: databaseDeploymentName(db)}
 		deploy.Spec.Selector = &metav1.LabelSelector{MatchLabels: matchLabels}
 		deploy.Spec.Replicas = ptr.To(int32(1))
 		mergePodTemplates(&deploy.Spec.Template, newDatabasePodTemplate(db, cctx.VersionInfo))
@@ -166,9 +166,9 @@ func ensureDatabaseService(cctx ControllerContext, db *metal3api.IronicDatabase)
 			cctx.Logger.Info("creating a new service")
 			service.ObjectMeta.Labels = make(map[string]string)
 		}
-		service.ObjectMeta.Labels[metal3api.IronicOperatorLabel] = databaseDeploymentName(db)
+		service.ObjectMeta.Labels[metal3api.IronicDatabaseLabel] = databaseDeploymentName(db)
 
-		service.Spec.Selector = map[string]string{metal3api.IronicOperatorLabel: databaseDeploymentName(db)}
+		service.Spec.Selector = map[string]string{metal3api.IronicDatabaseLabel: databaseDeploymentName(db)}
 		service.Spec.Ports = []corev1.ServicePort{
 			{
 				Protocol:   corev1.ProtocolTCP,

--- a/pkg/ironic/ironic.go
+++ b/pkg/ironic/ironic.go
@@ -35,7 +35,13 @@ func ensureIronicDaemonSet(cctx ControllerContext, ironic *metal3api.Ironic, db 
 		if deploy.ObjectMeta.CreationTimestamp.IsZero() {
 			cctx.Logger.Info("creating a new ironic daemon set")
 		}
-		matchLabels := map[string]string{metal3api.IronicOperatorLabel: ironicDeploymentName(ironic)}
+		if deploy.Labels == nil {
+			deploy.Labels = make(map[string]string, 2)
+		}
+		deploy.Labels[metal3api.IronicAppLabel] = ironicDeploymentName(ironic)
+		deploy.Labels[metal3api.IronicVersionLabel] = cctx.VersionInfo.InstalledVersion
+
+		matchLabels := map[string]string{metal3api.IronicAppLabel: ironicDeploymentName(ironic)}
 		deploy.Spec.Selector = &metav1.LabelSelector{MatchLabels: matchLabels}
 		mergePodTemplates(&deploy.Spec.Template, template)
 		return controllerutil.SetControllerReference(ironic, deploy, cctx.Scheme)
@@ -67,7 +73,13 @@ func ensureIronicDeployment(cctx ControllerContext, ironic *metal3api.Ironic, db
 		if deploy.ObjectMeta.CreationTimestamp.IsZero() {
 			cctx.Logger.Info("creating a new ironic deployment")
 		}
-		matchLabels := map[string]string{metal3api.IronicOperatorLabel: ironicDeploymentName(ironic)}
+		if deploy.Labels == nil {
+			deploy.Labels = make(map[string]string, 2)
+		}
+		deploy.Labels[metal3api.IronicAppLabel] = ironicDeploymentName(ironic)
+		deploy.Labels[metal3api.IronicVersionLabel] = cctx.VersionInfo.InstalledVersion
+
+		matchLabels := map[string]string{metal3api.IronicAppLabel: ironicDeploymentName(ironic)}
 		deploy.Spec.Selector = &metav1.LabelSelector{MatchLabels: matchLabels}
 		deploy.Spec.Replicas = ptr.To(int32(1))
 		mergePodTemplates(&deploy.Spec.Template, template)
@@ -101,9 +113,9 @@ func ensureIronicService(cctx ControllerContext, ironic *metal3api.Ironic) (Stat
 			cctx.Logger.Info("creating a new ironic service")
 			service.ObjectMeta.Labels = make(map[string]string)
 		}
-		service.ObjectMeta.Labels[metal3api.IronicOperatorLabel] = ironicDeploymentName(ironic)
+		service.ObjectMeta.Labels[metal3api.IronicAppLabel] = ironicDeploymentName(ironic)
 
-		service.Spec.Selector = map[string]string{metal3api.IronicOperatorLabel: ironicDeploymentName(ironic)}
+		service.Spec.Selector = map[string]string{metal3api.IronicAppLabel: ironicDeploymentName(ironic)}
 		service.Spec.Ports = []corev1.ServicePort{
 			{
 				Protocol:   corev1.ProtocolTCP,


### PR DESCRIPTION
Add a label with the Ironic version to all Ironic deployments and pods,
so that we can apply version-specific logic down the road.

Clean up the current labels: use the same prefix as the API group and do
not reuse the same label for Ironic and database to avoid conflicts.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
