### PR TITLE
🌱 CI: implement a test for TLS on Ironic API

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Run tests
       run: |
         cd test
+        . testing.env
         LOGDIR=/tmp/logs go test -timeout 60m
     - name: Collect logs
       run: LOGDIR=/tmp/logs ./test/collect-logs.sh

--- a/test/testing.env
+++ b/test/testing.env
@@ -1,0 +1,8 @@
+# Kind-specific settings to pass into the tests
+export PROVISIONING_IP="172.22.0.2"
+export PROVISIONING_CIDR="172.22.0.1/24"
+export PROVISIONING_INTERFACE="eth0"
+export IRONIC_IP="127.0.0.1"  # our Kind configuration proxies the port 6385
+
+export IRONIC_CERT_FILE=/tmp/ironic-tls.crt
+export IRONIC_KEY_FILE=/tmp/ironic-tls.key


### PR DESCRIPTION
Also make sure that environment-specific parameters come from prepare.sh
as variables rather than being hardcoded.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
