### PR TITLE
:seedling: fix OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,4 +5,4 @@ approvers:
 
 reviewers:
 - ironic-standalone-operator-maintainers
-- ironic-standalone-operator-reviewers
+#- ironic-standalone-operator-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,4 +8,4 @@ aliases:
   - Rozzii
   - tuminoid
 
-  ironic-standalone-operator-reviewers: {}
+  # ironic-standalone-operator-reviewers:


### PR DESCRIPTION
I think the {} does not work here, let's just have empty list instead.

Ref: https://github.com/metal3-io/ironic-standalone-operator/pull/114#issuecomment-2597617629
Alternatively, bot is being drunk...