### PR TITLE
🌱 Enable functional test to be used on ironic-image/mariadb-image

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,24 @@
+# Functional tests for ironic-standalone-operator
+
+This directory contains functional tests for IrSO that install Ironic in
+different configurations and make sure it comes up correctly.
+
+## Setup
+
+The tests assume a Kubernetes cluster with ironic-standalone-operator is
+available. A helper script `test/prepare.sh` can be used to configure the
+operator and its dependencies on a Kind cluster.
+
+## Environment variables
+
+Required:
+
+- `IRONIC_CERT_FILE` - TLS certificate file to use for Ironic API
+- `IRONIC_KEY_FILE` - private key file of the TLS certificate
+
+Optional:
+
+- `IRONIC_CUSTOM_IMAGE` - Ironic container image to use when testing
+- `IRONIC_CUSTOM_VERSION` - Ironic version to use when testing
+- `MARIADB_CUSTOM_IMAGE` - MariaDB container image to use with tests that
+  create a database


### PR DESCRIPTION
This change adds new environment variables to control which Ironic and
MariaDB images are used in the tests. The goal is to run the same suite
on both repositories to avoid regressions.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
