### PR TITLE
🌱 Clean-up the functional test scripts

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -1,39 +1,35 @@
-name: Functional
+name: Functional Tests
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
 
 jobs:
-  functional:
+  test:
     runs-on: ubuntu-latest
+    env:
+      LOGDIR: /tmp/logs
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Calculate go version
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
     - name: Set up Go
-      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
-    - uses: helm/kind-action@v1
+    - uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
       with:
         cluster_name: kind
         config: ./test/kind.yaml
     - name: Prepare tests
-      run: LOGDIR=/tmp/logs ./test/prepare.sh
+      run: ./test/prepare.sh
     - name: Run tests
-      run: |
-        cd test
-        . testing.env
-        LOGDIR=/tmp/logs go test -timeout 60m
+      run: ./test/run.sh
     - name: Collect logs
-      run: LOGDIR=/tmp/logs ./test/collect-logs.sh
+      run: ./test/collect-logs.sh
       if: always()
     - name: Upload logs artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: functional
         path: /tmp/logs/*

--- a/test/README.md
+++ b/test/README.md
@@ -7,7 +7,9 @@ different configurations and make sure it comes up correctly.
 
 The tests assume a Kubernetes cluster with ironic-standalone-operator is
 available. A helper script `test/prepare.sh` can be used to configure the
-operator and its dependencies on a Kind cluster.
+operator and its dependencies on a Kind cluster. Then you can use `test/run.sh`
+to run the tests themselves. Finally, `test/collect-logs.sh` can be used to
+store the logs to `LOGDIR` (see below).
 
 ## Environment variables
 
@@ -18,6 +20,8 @@ Required:
 
 Optional:
 
+- `LOGDIR` - directory where logs will be placed both runing the test run and
+  by `collect-logs.sh`
 - `IRONIC_CUSTOM_IMAGE` - Ironic container image to use when testing
 - `IRONIC_CUSTOM_VERSION` - Ironic version to use when testing
 - `MARIADB_CUSTOM_IMAGE` - MariaDB container image to use with tests that

--- a/test/collect-logs.sh
+++ b/test/collect-logs.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
+# NOTE(dtantsur): do not use -e, commands can fail if the test breaks early
 set -ux
 
 LOGDIR="${LOGDIR:-/tmp/logs}"

--- a/test/prepare.sh
+++ b/test/prepare.sh
@@ -1,13 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux -o pipefail
+
+REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
+cd "${REPO_ROOT}"
 
 IMG="${IMG:-localhost/controller:test}"
 LOGDIR="${LOGDIR:-/tmp/logs}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-}"
 CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-1.16.1}"
 
-. "$(dirname "$0")/testing.env"
+. test/testing.env
 
 mkdir -p "${LOGDIR}"
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
+cd "${REPO_ROOT}/test"
+
+LOGDIR="${LOGDIR:-/tmp/logs}"
+TEST_TIMEOUT="${TEST_TIMEOUT:-60m}"
+
+. testing.env
+
+mkdir -p "${LOGDIR}"
+
+exec go test -timeout "${TEST_TIMEOUT}"


### PR DESCRIPTION
* Do not run the workflow on push
* Pin all actions used in the workflow to their hashes
* Extract a separate run.sh for easier reuse in other jobs
* Make sure to cd to a predictable location (again, easier reuse)
* Consistently use /usr/bin/env in shebang
* Update the test README with missing information

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
