### PR TITLE
:seedling: workflows: sync pull_request trigger types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,8 @@
 name: Building and testing
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   test:

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -2,6 +2,7 @@ name: Functional Tests
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   test:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,7 +2,7 @@ name: golangci-lint
 
 on:
   pull_request:
-    types: [ opened, edited, synchronize, reopened ]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   golangci-lint:

--- a/.github/workflows/pr-gh-workflow-approve.yaml
+++ b/.github/workflows/pr-gh-workflow-approve.yaml
@@ -6,7 +6,8 @@ name: Approve GH Workflows
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize]
+    # edited is needed here as this workflow checks for PR meta content
+    types: [opened, edited, reopened, synchronize, ready_for_review]
 
 permissions: {}
 

--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -4,7 +4,8 @@ permissions: {}
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize]
+    # edited is needed here as this workflow checks for PR meta content
+    types: [opened, edited, reopened, synchronize, ready_for_review]
 
 jobs:
   verify:


### PR DESCRIPTION
We have "edited" as leftover workaround from days before we had "PR auto-reapprover" workflow in some jobs. In some jobs it is specifically needed as those workflows check the PR metadata which is covered by the edited. Add "ready_for_review" for consistency as a trigger type as well.

Similar PRs will be pushed across Metal3 repos to make things consistent after [discussion in ironic-image PR.](https://github.com/metal3-io/ironic-image/pull/620#pullrequestreview-2604851729)
