### PR TITLE
🌱 Functional tests: improve versions test, add upgrades

### DIFF
--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -26,6 +26,10 @@ const (
 )
 
 // Mapping of supported versions to container image tags.
+// This mapping must be updated each time a new ironic-image branch is created.
+// Also consider updating the version test(s) in test/suite_test.go to verify
+// that the new version is installable and its API version matches
+// expectations.
 var SupportedVersions = map[string]string{
 	VersionLatest: "latest",
 	Version270:    "release-27.0",

--- a/pkg/ironic/version.go
+++ b/pkg/ironic/version.go
@@ -7,10 +7,8 @@ import (
 )
 
 const (
-	versionLatest = "latest"
-	version270    = "27.0"
 	// NOTE(dtantsur): defaultVersion must be updated after branching
-	defaultVersion  = versionLatest
+	defaultVersion  = metal3api.VersionLatest
 	defaultRegistry = "quay.io/metal3-io"
 )
 

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -55,11 +55,17 @@ import (
 	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
 )
 
-// NOTE(dtantsur): latest is now at least 1.95
-const apiVersionIn270 = "1.94"
-
-// Update this periodically to make sure we're installing the latest version
-const knownAPIMinorVersion = 95
+// NOTE(dtantsur): these two constants refer to the Ironic API version (which
+// is different from the version of Ironic itself). Versions are incremented
+// every time the API is changed. The listing of all versions is here:
+// https://docs.openstack.org/ironic/latest/contributor/webapi-version-history.html
+const (
+	// NOTE(dtantsur): latest is now at least 1.95, so we can rely on this
+	// value to check that specifying Version: 27.0 actually installs 27.0
+	apiVersionIn270 = "1.94"
+	// Update this periodically to make sure we're installing the latest version by default
+	knownAPIMinorVersion = 95
+)
 
 var ctx context.Context
 var k8sClient client.Client


### PR DESCRIPTION
Currently, the relevant test just sets the Version field without any
further validation. Here I'm relying on API versions to check that
the correct version is installed since latest and 27.0 have diverged.

Try upgrading from 27.0 to latest.

Clean up redundant constants in version.go.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
