### PR TITLE
🐛 More precise status message in the Ready condition

### DIFF
--- a/pkg/ironic/ironic.go
+++ b/pkg/ironic/ironic.go
@@ -153,8 +153,7 @@ func removeIronicDeployment(cctx ControllerContext, ironic *metal3api.Ironic) er
 // EnsureIronic deploys Ironic either as a Deployment or as a DaemonSet.
 func EnsureIronic(cctx ControllerContext, ironic *metal3api.Ironic, db *metal3api.IronicDatabase, apiSecret *corev1.Secret) (status Status, err error) {
 	if db != nil && !isReady(db.Status.Conditions) {
-		cctx.Logger.Info("database is not ready yet")
-		return
+		return inProgress("database is not ready yet")
 	}
 
 	if validationErr := metal3api.ValidateIronic(&ironic.Spec, nil); validationErr != nil {

--- a/pkg/ironic/status.go
+++ b/pkg/ironic/status.go
@@ -1,12 +1,12 @@
 package ironic
 
 type Status struct {
-	// Object is reconciled but some resources may be in progress.
-	Reconciled bool
 	// Object is reconciled and all resources are ready.
 	Ready bool
 	// Fatal error, further reconciliation is not possible.
 	Fatal error
+	// Message explaining what is not ready.
+	Message string
 }
 
 func (status Status) IsError() bool {
@@ -22,11 +22,10 @@ func (status Status) String() string {
 		return status.Fatal.Error()
 	}
 
-	if !status.Reconciled {
-		return "resources are being updated"
-	}
-
 	if !status.Ready {
+		if status.Message != "" {
+			return status.Message
+		}
 		return "resources are not ready yet"
 	}
 
@@ -35,17 +34,17 @@ func (status Status) String() string {
 
 // Everything is done, no more reconciliation required.
 func ready() (Status, error) {
-	return Status{Reconciled: true, Ready: true}, nil
+	return Status{Ready: true}, nil
 }
 
 // We have updated dependent resources.
 func updated() (Status, error) {
-	return Status{}, nil
+	return Status{Message: "dependent resources are being updated"}, nil
 }
 
 // We are passively waiting for something external to happen.
-func inProgress() (Status, error) {
-	return Status{Reconciled: true}, nil
+func inProgress(message string) (Status, error) {
+	return Status{Message: message}, nil
 }
 
 // Checking or updating status failed, we hope it's going to resolve itself

--- a/pkg/ironic/utils.go
+++ b/pkg/ironic/utils.go
@@ -98,7 +98,7 @@ func getDeploymentStatus(cctx ControllerContext, deploy *appsv1.Deployment) (Sta
 	if deploy.Status.ObservedGeneration != deploy.Generation {
 		cctx.Logger.Info("deployment not ready yet", "Deployment", deploy.Name,
 			"Generation", deploy.Generation, "ObservedGeneration", deploy.Status.ObservedGeneration)
-		return inProgress()
+		return inProgress("deployment not ready yet")
 	}
 
 	var available bool
@@ -117,9 +117,9 @@ func getDeploymentStatus(cctx ControllerContext, deploy *appsv1.Deployment) (Sta
 	if available {
 		return ready()
 	} else {
-		cctx.Logger.Info("deployment not ready yet", "Deployment", deploy.Name,
+		cctx.Logger.Info("deployment not available yet", "Deployment", deploy.Name,
 			"Conditions", deploy.Status.Conditions)
-		return inProgress()
+		return inProgress("deployment not available yet")
 	}
 }
 
@@ -127,7 +127,7 @@ func getDaemonSetStatus(cctx ControllerContext, deploy *appsv1.DaemonSet) (Statu
 	if deploy.Status.ObservedGeneration != deploy.Generation {
 		cctx.Logger.Info("daemon set not ready yet", "DaemonSet", deploy.Name,
 			"Generation", deploy.Generation, "ObservedGeneration", deploy.Status.ObservedGeneration)
-		return inProgress()
+		return inProgress("daemon set not ready yet")
 	}
 
 	var available bool
@@ -149,16 +149,16 @@ func getDaemonSetStatus(cctx ControllerContext, deploy *appsv1.DaemonSet) (Statu
 	if available {
 		return ready()
 	} else {
-		cctx.Logger.Info("daemon set not ready yet", "DaemonSet", deploy.Name,
+		cctx.Logger.Info("daemon set not available yet", "DaemonSet", deploy.Name,
 			"NumberUnavailable", deploy.Status.NumberUnavailable)
-		return inProgress()
+		return inProgress(fmt.Sprintf("daemon set not available yet: %d replicas unavailable", deploy.Status.NumberUnavailable))
 	}
 }
 
 func getServiceStatus(service *corev1.Service) (Status, error) {
 	// TODO(dtantsur): can we check anything else?
 	if len(service.Spec.ClusterIPs) == 0 {
-		return inProgress()
+		return inProgress("service has no cluster IPs")
 	}
 
 	return ready()


### PR DESCRIPTION
This change replaces the pretty unhelpful "resources are being updated"
with an explanation of what exactly is being updated or is not ready.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
