### PR TITLE
:warning: Finish transition to typed Version

### DIFF
--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -20,10 +20,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	VersionLatest = "latest"
-	Version280    = "28.0"
-	Version270    = "27.0"
+var (
+	VersionLatest = Version{}
+	Version280    = Version{Major: 28, Minor: 0}
+	Version270    = Version{Major: 27, Minor: 0}
 )
 
 // Mapping of supported versions to container image tags.
@@ -31,7 +31,7 @@ const (
 // Also consider updating the version test(s) in test/suite_test.go to verify
 // that the new version is installable and its API version matches
 // expectations.
-var SupportedVersions = map[string]string{
+var SupportedVersions = map[Version]string{
 	VersionLatest: "latest",
 	Version280:    "release-28.0",
 	Version270:    "release-27.0",

--- a/api/v1alpha1/ironic_webhook_test.go
+++ b/api/v1alpha1/ironic_webhook_test.go
@@ -189,9 +189,16 @@ func TestValidateIronic(t *testing.T) {
 		{
 			Scenario: "with invalid version",
 			Ironic: IronicSpec{
-				Version: "0.42",
+				Version: "banana",
 			},
-			ExpectedError: "version 0.42 is not supported, supported versions are 27.0, 28.0, latest",
+			ExpectedError: "invalid version banana, expected MAJOR.MINOR",
+		},
+		{
+			Scenario: "with unsupported version",
+			Ironic: IronicSpec{
+				Version: "42.42",
+			},
+			ExpectedError: "version 42.42 is not supported, supported versions are 27.0, 28.0, latest",
 		},
 	}
 

--- a/api/v1alpha1/version.go
+++ b/api/v1alpha1/version.go
@@ -1,37 +1,63 @@
 package v1alpha1
 
 import (
+	"cmp"
 	"fmt"
 	"slices"
 	"strconv"
 	"strings"
 )
 
+const versionLatestString = "latest"
+
 type Version struct {
 	Major, Minor int
+}
+
+func (v Version) Compare(other Version) int {
+	if v.IsLatest() {
+		if other.IsLatest() {
+			return 0
+		}
+		return 1
+	}
+
+	if v.Major != other.Major {
+		return cmp.Compare(v.Major, other.Major)
+	}
+
+	return cmp.Compare(v.Minor, other.Minor)
 }
 
 func (v Version) IsLatest() bool {
 	return v.Major == 0
 }
 
+func (v Version) String() string {
+	if v.IsLatest() {
+		return versionLatestString
+	}
+
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
+
 func ParseVersion(version string) (Version, error) {
-	if version == VersionLatest {
+	if version == versionLatestString {
 		return Version{}, nil
 	}
 
 	versionSplit := strings.SplitN(version, ".", 2)
 	if len(versionSplit) != 2 {
-		return Version{}, fmt.Errorf("invalid version %s, expected X.Y", version)
+		return Version{}, fmt.Errorf("invalid version %s, expected MAJOR.MINOR", version)
 	}
 
 	major, err := strconv.Atoi(versionSplit[0])
 	if err != nil || major <= 0 {
-		return Version{}, fmt.Errorf("invalid major version %s", versionSplit[0])
+		return Version{}, fmt.Errorf("invalid major version %s in %s", versionSplit[0], version)
 	}
 	minor, err := strconv.Atoi(versionSplit[1])
 	if err != nil {
-		return Version{}, fmt.Errorf("invalid minor version %s", versionSplit[1])
+		return Version{}, fmt.Errorf("invalid minor version %s in %s", versionSplit[1], version)
 	}
 
 	return Version{Major: major, Minor: minor}, nil
@@ -47,10 +73,15 @@ func MustParseVersion(version string) Version {
 }
 
 func ValidateVersion(version string) error {
-	if SupportedVersions[version] == "" {
+	parsed, err := ParseVersion(version)
+	if err != nil {
+		return err
+	}
+
+	if SupportedVersions[parsed] == "" {
 		var versions []string
 		for ver := range SupportedVersions {
-			versions = append(versions, ver)
+			versions = append(versions, ver.String())
 		}
 		slices.Sort(versions)
 		return fmt.Errorf("version %s is not supported, supported versions are %s",
@@ -58,10 +89,4 @@ func ValidateVersion(version string) error {
 	}
 
 	return nil
-}
-
-func init() {
-	for version := range SupportedVersions {
-		MustParseVersion(version)
-	}
 }

--- a/api/v1alpha1/version_test.go
+++ b/api/v1alpha1/version_test.go
@@ -1,0 +1,114 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsing(t *testing.T) {
+	testCases := []struct {
+		Scenario string
+
+		Value string
+
+		Expected    Version
+		ExpectError string
+	}{
+		{
+			Scenario: "latest",
+			Value:    "latest",
+		},
+		{
+			Scenario: "valid major",
+			Value:    "27.0",
+			Expected: Version{Major: 27, Minor: 0},
+		},
+		{
+			Scenario: "valid minor",
+			Value:    "27.2",
+			Expected: Version{Major: 27, Minor: 2},
+		},
+		{
+			Scenario:    "invalid leading zero",
+			Value:       "0.42",
+			ExpectError: "invalid major version 0 in 0.42",
+		},
+		{
+			Scenario:    "invalid major",
+			Value:       "foo.42",
+			ExpectError: "invalid major version foo in foo.42",
+		},
+		{
+			Scenario:    "invalid minor",
+			Value:       "42.foo",
+			ExpectError: "invalid minor version foo in 42.foo",
+		},
+		{
+			Scenario:    "invalid structure",
+			Value:       "1,2",
+			ExpectError: "invalid version 1,2, expected MAJOR.MINOR",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			result, err := ParseVersion(tc.Value)
+			if tc.ExpectError != "" {
+				assert.ErrorContains(t, err, tc.ExpectError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.Expected, result)
+			}
+		})
+	}
+}
+
+func TestComparing(t *testing.T) {
+	testCases := []struct {
+		Scenario string
+
+		First  Version
+		Second Version
+
+		Expected int
+	}{
+		{
+			Scenario: "latest equal latest",
+			First:    VersionLatest,
+			Second:   VersionLatest,
+			Expected: 0,
+		},
+		{
+			Scenario: "latest > any",
+			First:    VersionLatest,
+			Second:   Version{Major: 99, Minor: 99},
+			Expected: 1,
+		},
+		{
+			Scenario: "equal",
+			First:    Version{Major: 42, Minor: 0},
+			Second:   Version{Major: 42, Minor: 0},
+			Expected: 0,
+		},
+		{
+			Scenario: "compare major",
+			First:    Version{Major: 41, Minor: 99},
+			Second:   Version{Major: 42, Minor: 0},
+			Expected: -1,
+		},
+		{
+			Scenario: "compare minor",
+			First:    Version{Major: 42, Minor: 99},
+			Second:   Version{Major: 42, Minor: 0},
+			Expected: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			result := tc.First.Compare(tc.Second)
+			assert.Equal(t, tc.Expected, result)
+		})
+	}
+}

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -122,7 +122,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 	}
 	cctx.VersionInfo = versionInfo
 
-	actuallyRequestedVersion := cctx.VersionInfo.InstalledVersion
+	actuallyRequestedVersion := cctx.VersionInfo.InstalledVersion.String()
 	if actuallyRequestedVersion != ironicConf.Status.InstalledVersion && actuallyRequestedVersion != ironicConf.Status.RequestedVersion {
 		cctx.Logger.Info("new version requested", "InstalledVersion", ironicConf.Status.InstalledVersion, "RequestedVersion", actuallyRequestedVersion)
 		ironicConf.Status.RequestedVersion = actuallyRequestedVersion
@@ -152,7 +152,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 	newStatus.InstalledVersion = ""
 	requeue = setConditionsFromStatus(cctx, status, &newStatus.Conditions, ironicConf.Generation, "ironic")
 	if !requeue {
-		newStatus.InstalledVersion = cctx.VersionInfo.InstalledVersion
+		newStatus.InstalledVersion = actuallyRequestedVersion
 	}
 
 	if !apiequality.Semantic.DeepEqual(newStatus, &ironicConf.Status) {

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -479,8 +479,6 @@ func newIronicPodTemplate(cctx ControllerContext, ironic *metal3api.Ironic, db *
 
 	var ipaDownloaderVars []corev1.EnvVar
 	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
-		"IPA_BASEURI", cctx.VersionInfo.AgentDownloadURL)
-	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
 		"IPA_BRANCH", cctx.VersionInfo.AgentBranch)
 
 	volumes, mounts := buildIronicVolumesAndMounts(ironic, db)

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -572,7 +572,7 @@ func newIronicPodTemplate(cctx ControllerContext, ironic *metal3api.Ironic, db *
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				metal3api.IronicAppLabel:     ironicDeploymentName(ironic),
-				metal3api.IronicVersionLabel: cctx.VersionInfo.InstalledVersion,
+				metal3api.IronicVersionLabel: cctx.VersionInfo.InstalledVersion.String(),
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/pkg/ironic/ironic.go
+++ b/pkg/ironic/ironic.go
@@ -39,7 +39,7 @@ func ensureIronicDaemonSet(cctx ControllerContext, ironic *metal3api.Ironic, db 
 			deploy.Labels = make(map[string]string, 2)
 		}
 		deploy.Labels[metal3api.IronicAppLabel] = ironicDeploymentName(ironic)
-		deploy.Labels[metal3api.IronicVersionLabel] = cctx.VersionInfo.InstalledVersion
+		deploy.Labels[metal3api.IronicVersionLabel] = cctx.VersionInfo.InstalledVersion.String()
 
 		matchLabels := map[string]string{metal3api.IronicAppLabel: ironicDeploymentName(ironic)}
 		deploy.Spec.Selector = &metav1.LabelSelector{MatchLabels: matchLabels}
@@ -77,7 +77,7 @@ func ensureIronicDeployment(cctx ControllerContext, ironic *metal3api.Ironic, db
 			deploy.Labels = make(map[string]string, 2)
 		}
 		deploy.Labels[metal3api.IronicAppLabel] = ironicDeploymentName(ironic)
-		deploy.Labels[metal3api.IronicVersionLabel] = cctx.VersionInfo.InstalledVersion
+		deploy.Labels[metal3api.IronicVersionLabel] = cctx.VersionInfo.InstalledVersion.String()
 
 		matchLabels := map[string]string{metal3api.IronicAppLabel: ironicDeploymentName(ironic)}
 		deploy.Spec.Selector = &metav1.LabelSelector{MatchLabels: matchLabels}

--- a/pkg/ironic/version.go
+++ b/pkg/ironic/version.go
@@ -19,7 +19,7 @@ var (
 )
 
 type VersionInfo struct {
-	InstalledVersion       string
+	InstalledVersion       metal3api.Version
 	IronicImage            string
 	MariaDBImage           string
 	RamdiskDownloaderImage string
@@ -29,16 +29,16 @@ type VersionInfo struct {
 
 // Creates a version info from images and version.
 func NewVersionInfo(ironicImages metal3api.Images, ironicVersion string, databaseImage string) (result VersionInfo, err error) {
-	parsedVersion := defaultVersion
 	if ironicVersion != "" {
-		parsedVersion, err = metal3api.ParseVersion(ironicVersion)
+		parsedVersion, err := metal3api.ParseVersion(ironicVersion)
 		if err != nil {
-			return
+			return VersionInfo{}, err
 		}
+		result.InstalledVersion = parsedVersion
+	} else {
+		result.InstalledVersion = defaultVersion
 	}
-	tag := metal3api.SupportedVersions[parsedVersion]
-
-	result.InstalledVersion = parsedVersion.String()
+	tag := metal3api.SupportedVersions[result.InstalledVersion]
 
 	if ironicImages.Ironic != "" {
 		result.IronicImage = ironicImages.Ironic
@@ -81,7 +81,7 @@ func (versionInfo VersionInfo) WithIronicOverrides(ironic *metal3api.Ironic) (Ve
 		if err != nil {
 			return VersionInfo{}, err
 		}
-		versionInfo.InstalledVersion = ironic.Spec.Version
+		versionInfo.InstalledVersion = parsedVersion
 
 		// NOTE(dtantsur): a non-default version requires a different default image
 		if images.Ironic == "" {

--- a/pkg/ironic/version_test.go
+++ b/pkg/ironic/version_test.go
@@ -12,8 +12,10 @@ func TestWithIronicOverrides(t *testing.T) {
 	testCases := []struct {
 		Scenario string
 
-		Configured VersionInfo
-		Ironic     metal3api.Ironic
+		DefaultIronicImages  metal3api.Images
+		DefaultIronicVersion string
+		DefaultDatabaseImage string
+		Ironic               metal3api.Ironic
 
 		Expected    VersionInfo
 		ExpectError string
@@ -27,6 +29,7 @@ func TestWithIronicOverrides(t *testing.T) {
 				IronicImage:            "quay.io/metal3-io/ironic:latest",
 				KeepalivedImage:        "quay.io/metal3-io/keepalived:latest",
 				RamdiskDownloaderImage: "quay.io/metal3-io/ironic-ipa-downloader:latest",
+				MariaDBImage:           "quay.io/metal3-io/mariadb:latest",
 			},
 		},
 		{
@@ -50,6 +53,7 @@ func TestWithIronicOverrides(t *testing.T) {
 				IronicImage:            "myorg/ironic:tag",
 				KeepalivedImage:        "myorg/keepalived:tag",
 				RamdiskDownloaderImage: "myorg/ramdisk-downloader:tag",
+				MariaDBImage:           "quay.io/metal3-io/mariadb:latest",
 			},
 		},
 		{
@@ -82,6 +86,7 @@ func TestWithIronicOverrides(t *testing.T) {
 				IronicImage:            "quay.io/metal3-io/ironic:release-27.0",
 				KeepalivedImage:        "quay.io/metal3-io/keepalived:latest",
 				RamdiskDownloaderImage: "quay.io/metal3-io/ironic-ipa-downloader:latest",
+				MariaDBImage:           "quay.io/metal3-io/mariadb:latest",
 			},
 		},
 		{
@@ -99,7 +104,9 @@ func TestWithIronicOverrides(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			result, err := tc.Configured.WithIronicOverrides(&tc.Ironic)
+			defaults, err := NewVersionInfo(tc.DefaultIronicImages, tc.DefaultIronicVersion, tc.DefaultDatabaseImage)
+			assert.NoError(t, err)
+			result, err := defaults.WithIronicOverrides(&tc.Ironic)
 			if tc.ExpectError != "" {
 				assert.ErrorContains(t, err, tc.ExpectError)
 			} else {

--- a/pkg/ironic/version_test.go
+++ b/pkg/ironic/version_test.go
@@ -25,7 +25,7 @@ func TestWithIronicOverrides(t *testing.T) {
 
 			Expected: VersionInfo{
 				// NOTE(dtantsur): this value will change on stable branches
-				InstalledVersion:       "latest",
+				InstalledVersion:       metal3api.VersionLatest,
 				IronicImage:            "quay.io/metal3-io/ironic:latest",
 				KeepalivedImage:        "quay.io/metal3-io/keepalived:latest",
 				RamdiskDownloaderImage: "quay.io/metal3-io/ironic-ipa-downloader:latest",
@@ -49,7 +49,7 @@ func TestWithIronicOverrides(t *testing.T) {
 			Expected: VersionInfo{
 				AgentBranch: "stable/x.y",
 				// NOTE(dtantsur): this value will change on stable branches
-				InstalledVersion:       "latest",
+				InstalledVersion:       metal3api.VersionLatest,
 				IronicImage:            "myorg/ironic:tag",
 				KeepalivedImage:        "myorg/keepalived:tag",
 				RamdiskDownloaderImage: "myorg/ramdisk-downloader:tag",
@@ -66,10 +66,11 @@ func TestWithIronicOverrides(t *testing.T) {
 			},
 
 			Expected: VersionInfo{
-				InstalledVersion:       "28.0",
+				InstalledVersion:       metal3api.Version280,
 				IronicImage:            "quay.io/metal3-io/ironic:release-28.0",
 				KeepalivedImage:        "quay.io/metal3-io/keepalived:latest",
 				RamdiskDownloaderImage: "quay.io/metal3-io/ironic-ipa-downloader:latest",
+				MariaDBImage:           "quay.io/metal3-io/mariadb:latest",
 			},
 		},
 		{
@@ -82,7 +83,7 @@ func TestWithIronicOverrides(t *testing.T) {
 			},
 
 			Expected: VersionInfo{
-				InstalledVersion:       "27.0",
+				InstalledVersion:       metal3api.Version270,
 				IronicImage:            "quay.io/metal3-io/ironic:release-27.0",
 				KeepalivedImage:        "quay.io/metal3-io/keepalived:latest",
 				RamdiskDownloaderImage: "quay.io/metal3-io/ironic-ipa-downloader:latest",


### PR DESCRIPTION
Currently, an incomplete VersionInfo is passed around until it's fully validated when the Ironic object is available.
Furthermore, Version is passed as a string, requiring conversion for any comparisons (there will be many of them in the near future once we start writing version-specific logic).

This series of commits refactors the handling of Version and VersionInfo so that
1. An invalid VersionInfo object is never constructed
2. A potentially invalid version string is never passed around
3. Defaults for VersionInfo are applied when constructing it, not when overriding the defaults from the CR
4. `init`-time validation of versions is no longer required

A comparison function is added to Version for the future use.

These changes are technically breaking since the types of public constants and types are changed.