### PR TITLE
:seedling: add go ecosystem to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,5 +14,30 @@ updates:
     prefix: ":seedling:"
   labels:
   - "ok-to-test"
+- package-ecosystem: "gomod"
+  directories:
+  - "/"
+  - "/test"
+  schedule:
+    interval: "weekly"
+    day: "thursday"
+  target-branch: main
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: ["k8s.io/*"]
+  ignore:
+  # Ignore controller-runtime major and minor bumps as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s major and minor bumps and its transitives modules
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  - dependency-name: "sigs.k8s.io/controller-tools"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
 
 ## main branch config ends here


### PR DESCRIPTION
Add go ecosystem to dependabot config, so we get automated updates for go modules.