### PR TITLE
🐛 Fix probes for httpd when the downloader is disabled

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -800,6 +800,28 @@ var _ = Describe("Ironic object tests", func() {
 		ironic = WaitForIronic(name)
 		VerifyIronic(ironic, TestAssumptions{activeConductor: conductorName})
 	})
+
+	It("creates Ironic with disabled downloader", Label("disabled-downloader"), func() {
+		name := types.NamespacedName{
+			Name:      "test-ironic",
+			Namespace: namespace,
+		}
+
+		ironic := buildIronic(name, metal3api.IronicSpec{
+			DeployRamdisk: metal3api.DeployRamdisk{
+				DisableDownloader: true,
+			},
+		})
+		err := k8sClient.Create(ctx, ironic)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			CollectLogs(namespace)
+			DeleteAndWait(ironic)
+		})
+
+		ironic = WaitForIronic(name)
+		VerifyIronic(ironic, TestAssumptions{})
+	})
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
The current probes rely on /images path which is created by the
downloader, so the probe fails when it's disabled.

Even worse, we're relying on an HTTP redirect from /images to /images/ being
interpreted as success by cURL. Adding -L uncovers the issue: /images/
returns HTTP 404. So, use -L to avoid false positives and switch to
a known path that the downloader creates.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
