### PR TITLE
:seedling: add dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,51 @@
+name: dependabot
+
+on:
+  pull_request:
+    branches:
+    - dependabot/**
+  push:
+    branches:
+    - dependabot/**
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Calculate go version
+      id: vars
+      run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
+    - name: Set up Go
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+      with:
+        go-version: ${{ steps.vars.outputs.go_version }}
+    - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+      name: Restore go cache
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Update all modules
+      run: make modules
+    - name: Update generated code
+      run: make generate
+    - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
+      name: Commit changes
+      with:
+        author_name: dependabot[bot]
+        author_email: 49699333+dependabot[bot]@users.noreply.github.com
+        default_author: github_actor
+        message: 'Update generated code'


### PR DESCRIPTION
In addition to dependabot config that allows dependabot to create PRs for bumps, for Go ecosystem we also need a dependabot workflow that after bumps also adds commit with result of "make modules", and "make generate" to each dependabot commit.

I forgot to add this when adding dependabot config for the Go.