### PR TITLE
⚠️ Deprecate the IronicDatabase API and spec.databaseName on Ironic

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -123,3 +123,9 @@ issues:
   - EXC0002 # include "missing comments" issues from golangci-lint
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-rules:
+  # NOTE(dtantsur): IronicDatabase is deprecated but our own code still supports it.
+  # Remove this exclusion when it's entirely deleted.
+  - linters:
+      - staticcheck
+    text: "SA1019: (metal3api.IronicDatabase|metal3iov1alpha1.IronicDatabase|ironicConf.Spec.DatabaseName) is deprecated"

--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -238,6 +238,8 @@ type IronicSpec struct {
 
 	// DatabaseName is a reference to the IronicDatabase object.
 	// If missing, a local SQLite database will be used. Must be provided for a highly available architecture.
+	//
+	// Deprecated: the IronicDatabase API is deprecated and will be removed soon in favour of explicit connection parameters.
 	// +optional
 	DatabaseName string `json:"databaseName,omitempty"`
 

--- a/api/v1alpha1/ironicdatabase_types.go
+++ b/api/v1alpha1/ironicdatabase_types.go
@@ -50,7 +50,9 @@ type IronicDatabaseStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// IronicDatabase is the Schema for the ironicdatabases API
+// IronicDatabase is the Schema for the ironic database API.
+//
+// Deprecated: the IronicDatabase API is deprecated and will be removed soon in favour of 3rd party database operators.
 type IronicDatabase struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/ironic.metal3.io_ironicdatabases.yaml
+++ b/config/crd/bases/ironic.metal3.io_ironicdatabases.yaml
@@ -17,7 +17,11 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: IronicDatabase is the Schema for the ironicdatabases API
+        description: |-
+          IronicDatabase is the Schema for the ironic database API.
+
+
+          Deprecated: the IronicDatabase API is deprecated and will be removed soon in favour of 3rd party database operators.
         properties:
           apiVersion:
             description: |-

--- a/config/crd/bases/ironic.metal3.io_ironics.yaml
+++ b/config/crd/bases/ironic.metal3.io_ironics.yaml
@@ -62,6 +62,9 @@ spec:
                 description: |-
                   DatabaseName is a reference to the IronicDatabase object.
                   If missing, a local SQLite database will be used. Must be provided for a highly available architecture.
+
+
+                  Deprecated: the IronicDatabase API is deprecated and will be removed soon in favour of explicit connection parameters.
                 type: string
               deployRamdisk:
                 description: DeployRamdisk defines settings for the provisioning/inspection


### PR DESCRIPTION
We should not be in the business of managing databases. Our
mariadb-image has known issues in the initialization code, does not
support HA and cannot do upgrades. There are 3rd party solutions that
are much more production-ready, just use them.

Part of: #142

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
