### PR TITLE
🐛 Forbid setting networking.dhcp in the HA architecture

### DIFF
--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -112,6 +112,7 @@ type Networking struct {
 
 	// DHCP is a configuration of DHCP for the network boot service (dnsmasq).
 	// The service is only deployed when this is set.
+	// This setting is currently incompatible with the highly available architecture.
 	DHCP *DHCP `json:"dhcp,omitempty"`
 
 	// ExternalIP is used for accessing API and the image server from remote hosts.
@@ -251,7 +252,8 @@ type IronicSpec struct {
 
 	// HighAvailability causes Ironic to be deployed as a DaemonSet on control plane nodes instead of a deployment with 1 replica.
 	// Requires database to be installed and linked to DatabaseName.
-	// EXPERIMENTAL: do not use (validation will fail)!
+	// DHCP support is not yet implemented in the highly available architecture.
+	// EXPERIMENTAL: do not use, the implementation is incomplete.
 	// +optional
 	HighAvailability bool `json:"highAvailability,omitempty"`
 

--- a/api/v1alpha1/ironic_webhook.go
+++ b/api/v1alpha1/ironic_webhook.go
@@ -200,6 +200,10 @@ func ValidateIronic(ironic *IronicSpec, old *IronicSpec) error {
 	}
 
 	if dhcp := ironic.Networking.DHCP; dhcp != nil {
+		if ironic.HighAvailability {
+			return errors.New("DHCP support is not implemented in the highly available architecture")
+		}
+
 		if err := ValidateDHCP(ironic, dhcp); err != nil {
 			return err
 		}

--- a/api/v1alpha1/ironic_webhook_test.go
+++ b/api/v1alpha1/ironic_webhook_test.go
@@ -121,6 +121,17 @@ func TestValidateIronic(t *testing.T) {
 			ExpectedError: "highly available architecture is disabled",
 		},
 		{
+			Scenario: "no DHCP with HA",
+			Ironic: IronicSpec{
+				DatabaseName:     "db",
+				HighAvailability: true,
+				Networking: Networking{
+					DHCP: &DHCP{},
+				},
+			},
+			ExpectedError: "DHCP support is not implemented",
+		},
+		{
 			Scenario: "With Keepalived, no DHCP",
 			Ironic: IronicSpec{
 				Networking: Networking{

--- a/config/crd/bases/ironic.metal3.io_ironics.yaml
+++ b/config/crd/bases/ironic.metal3.io_ironics.yaml
@@ -105,7 +105,8 @@ spec:
                 description: |-
                   HighAvailability causes Ironic to be deployed as a DaemonSet on control plane nodes instead of a deployment with 1 replica.
                   Requires database to be installed and linked to DatabaseName.
-                  EXPERIMENTAL: do not use (validation will fail)!
+                  DHCP support is not yet implemented in the highly available architecture.
+                  EXPERIMENTAL: do not use, the implementation is incomplete.
                 type: boolean
               images:
                 description: Images is a collection of container images to deploy
@@ -165,6 +166,7 @@ spec:
                     description: |-
                       DHCP is a configuration of DHCP for the network boot service (dnsmasq).
                       The service is only deployed when this is set.
+                      This setting is currently incompatible with the highly available architecture.
                     properties:
                       dnsAddress:
                         description: |-


### PR DESCRIPTION
There is literally no code written to support it, the DHCP settings are
silently ignored. Make this condition an error.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
