### PR TITLE
:seedling: bump action/checkout to v4, and pin it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Calculate go version
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
@@ -21,7 +21,7 @@ jobs:
   container:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Update repositories
       run: sudo apt update
     - name: Install podman
@@ -31,7 +31,7 @@ jobs:
   manifests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Calculate go version
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Bump action/checkout to latest v4.2.2, and pin it. We have dependabot in place to keep the pinnings up to date.

Replaces: https://github.com/metal3-io/ironic-standalone-operator/pull/131