### PR TITLE
🌱 Bump golangci-lint to v1.64.7

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,8 +26,8 @@ jobs:
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
     - name: golangci-lint-${{matrix.working-directory}}
-      uses: golangci/golangci-lint-action@051d91933864810ecd5e2ea2cfd98f6a5bca5347 # v6.3.2
+      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
       with:
-        version: v1.60.3
+        version: v1.64.7
         working-directory: ${{matrix.working-directory}}
         args: --timeout=10m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  deadline: 10m
+  go: "1.23"
 linters:
   disable-all: true
   enable:
@@ -51,7 +51,6 @@ linters:
   fast: true
 linters-settings:
   gosec:
-    go: "1.23"
     severity: medium
     confidence: medium
     concurrency: 8
@@ -82,7 +81,6 @@ linters-settings:
       alias: ironicv1alpha1
   nolintlint:
     allow-unused: false
-    allow-leading-space: false
     require-specific: true
   gocritic:
     enabled-tags:
@@ -101,14 +99,17 @@ linters-settings:
     - unnecessaryDefer
     - whyNoLint
     - wrapperFunc
-  unused:
-    go: "1.23"
 issues:
-  skip-dirs:
+  exclude-dirs:
   - mock*
-  skip-files:
+  exclude-files:
   - "zz_generated.*\\.go$"
   - ".*conversion.*\\.go$"
+  include:
+  - EXC0002 # include "missing comments" issues from golangci-lint
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-rules:
   - linters:
     - staticcheck
     text: "SA1019:"
@@ -119,11 +120,6 @@ issues:
   - linters:
     - revive
     text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
-  include:
-  - EXC0002 # include "missing comments" issues from golangci-lint
-  max-issues-per-linter: 0
-  max-same-issues: 0
-  exclude-rules:
   # NOTE(dtantsur): IronicDatabase is deprecated but our own code still supports it.
   # Remove this exclusion when it's entirely deleted.
   - linters:

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.2
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
-GOLANGCI_LINT_VERSION ?= v1.60.3
+GOLANGCI_LINT_VERSION ?= v1.64.7
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize


### PR DESCRIPTION
This PR also bumps golangci-lint-action to 6.5.2. While doing that it removes some of the old unsupported golangci-lint settings.
Signed-off-by: Kashif Khan <kashif.khan@est.tech>