### PR TITLE
🌱 Fix the broken golang-ci linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,8 @@
+version: "2"
 run:
   go: "1.23"
 linters:
-  disable-all: true
+  default: fast
   enable:
   - asasalint
   - asciicheck
@@ -25,7 +26,7 @@ linters:
   - gosec
   #- gosimple
   - govet
-  #- importas
+  - importas
   - ineffassign
   - loggercheck
   - misspell
@@ -47,73 +48,66 @@ linters:
   - unused
   - usestdlibvars
   - whitespace
-  # Run with --fast=false for more extensive checks
-  fast: true
-linters-settings:
-  gosec:
-    severity: medium
-    confidence: medium
-    concurrency: 8
-    # (NOTE)elfosardo: we should try removing this exclude once we bump golangci-lint to 1.61
-    excludes:
-      - G115
-  importas:
-    no-unaliased: true
-    alias:
-    # Kubernetes
-    - pkg: k8s.io/api/core/v1
-      alias: corev1
-    - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
-      alias: apiextensionsv1
-    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-      alias: metav1
-    - pkg: k8s.io/apimachinery/pkg/api/errors
-      alias: k8serrors
-    - pkg: k8s.io/apimachinery/pkg/util/errors
-      alias: kerrors
-    - pkg: k8s.io/component-base/logs/api/v1
-      alias: logsv1
-    # Controller Runtime
-    - pkg: sigs.k8s.io/controller-runtime
-      alias: ctrl
-    # IrSO
-    - pkg: github.com/metal3-io/ironic-standalone-operator/api/v1alpha1
-      alias: ironicv1alpha1
-  nolintlint:
-    allow-unused: false
-    require-specific: true
-  gocritic:
-    enabled-tags:
-    - experimental
-    disabled-checks:
-    - appendAssign
-    - dupImport # https://github.com/go-critic/go-critic/issues/845
-    - evalOrder
-    - ifElseChain
-    - octalLiteral
-    - regexpSimplify
-    - sloppyReassign
-    - truncateCmp
-    - typeDefFirst
-    - unnamedResult
-    - unnecessaryDefer
-    - whyNoLint
-    - wrapperFunc
+  settings:
+    gosec:
+      severity: medium
+      confidence: medium
+    importas:
+      no-unaliased: true
+      alias:
+      # Kubernetes
+      - pkg: k8s.io/api/core/v1
+        alias: corev1
+      - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+        alias: apiextensionsv1
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1
+      - pkg: k8s.io/apimachinery/pkg/api/errors
+        alias: k8serrors
+      - pkg: k8s.io/apimachinery/pkg/util/errors
+        alias: kerrors
+      - pkg: k8s.io/component-base/logs/api/v1
+        alias: logsv1
+      # Controller Runtime
+      - pkg: sigs.k8s.io/controller-runtime
+        alias: ctrl
+      # IrSO
+      - pkg: github.com/metal3-io/ironic-standalone-operator/api/v1alpha1
+        alias: ironicv1alpha1
+    nolintlint:
+      allow-unused: false
+      require-specific: true
+    gocritic:
+      enabled-tags:
+      - experimental
+      disabled-checks:
+      - appendAssign
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - evalOrder
+      - ifElseChain
+      - octalLiteral
+      - regexpSimplify
+      - sloppyReassign
+      - truncateCmp
+      - typeDefFirst
+      - unnamedResult
+      - unnecessaryDefer
+      - whyNoLint
+      - wrapperFunc
+  exclusions:
+    paths:
+    - ".*/zz_generated.*\\.go$"
+    - ".*conversion.*\\.go$"
+    rules:
+    # Dot imports for gomega or ginkgo are allowed
+    # within test files.
+    - path: test/.*.go
+      text: should not use dot imports
+    # NOTE(dtantsur): IronicDatabase is deprecated but our own code still supports it.
+    # Remove this exclusion when it's entirely deleted.
+    - linters:
+        - staticcheck
+      text: "SA1019: (metal3api.IronicDatabase|metal3iov1alpha1.IronicDatabase|ironicConf.Spec.DatabaseName|ironic.DatabaseName|old.DatabaseName) is deprecated"
 issues:
-  exclude-files:
-  - "zz_generated.*\\.go$"
-  - ".*conversion.*\\.go$"
-  include:
-  - EXC0002 # include "missing comments" issues from golangci-lint
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-rules:
-  # Dot imports for gomega or ginkgo are allowed
-  # within test files.
-  - path: test/.*.go
-    text: should not use dot imports
-  # NOTE(dtantsur): IronicDatabase is deprecated but our own code still supports it.
-  # Remove this exclusion when it's entirely deleted.
-  - linters:
-      - staticcheck
-    text: "SA1019: (metal3api.IronicDatabase|metal3iov1alpha1.IronicDatabase|ironicConf.Spec.DatabaseName|ironic.DatabaseName|old.DatabaseName) is deprecated"

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,7 @@ $(GOLANGCI_LINT): $(LOCALBIN) ## Download golangci-lint locally if necessary. If
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) config verify
 	$(GOLANGCI_LINT) run -v ./... --timeout=10m
 	cd api; $(GOLANGCI_LINT) run -v ./... --timeout=10m
 	cd internal/controller; $(GOLANGCI_LINT) run -v ./... --timeout=10m

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -218,7 +218,10 @@ func (r *IronicReconciler) ensureAPISecret(cctx ironic.ControllerContext, ironic
 	}
 
 	oldReferences := apiSecret.GetOwnerReferences()
-	controllerutil.SetOwnerReference(ironicConf, apiSecret, cctx.Scheme)
+	err = controllerutil.SetOwnerReference(ironicConf, apiSecret, cctx.Scheme)
+	if err != nil {
+		return nil, true, err
+	}
 	if !reflect.DeepEqual(oldReferences, apiSecret.GetOwnerReferences()) {
 		cctx.Logger.Info("updating owner reference", "Secret", apiSecret.Name)
 		err = cctx.Client.Update(cctx.Context, apiSecret)
@@ -261,7 +264,10 @@ func (r *IronicReconciler) ensureDatabase(cctx ironic.ControllerContext, ironicC
 	}
 
 	oldReferences := db.GetOwnerReferences()
-	controllerutil.SetControllerReference(ironicConf, db, cctx.Scheme)
+	err = controllerutil.SetControllerReference(ironicConf, db, cctx.Scheme)
+	if err != nil {
+		return nil, true, err
+	}
 	if !reflect.DeepEqual(oldReferences, db.GetOwnerReferences()) {
 		cctx.Logger.Info("updating owner reference", "Database", db.Name)
 		err = cctx.Client.Update(cctx.Context, db)

--- a/pkg/ironic/ironic.go
+++ b/pkg/ironic/ironic.go
@@ -104,7 +104,7 @@ func ensureIronicService(cctx ControllerContext, ironic *metal3api.Ironic) (Stat
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: ironic.Name, Namespace: ironic.Namespace},
 	}
-	exposedPort := 80
+	exposedPort := int32(80)
 	if ironic.Spec.TLS.CertificateName != "" {
 		exposedPort = 443
 	}
@@ -119,7 +119,7 @@ func ensureIronicService(cctx ControllerContext, ironic *metal3api.Ironic) (Stat
 		service.Spec.Ports = []corev1.ServicePort{
 			{
 				Protocol:   corev1.ProtocolTCP,
-				Port:       int32(exposedPort),
+				Port:       exposedPort,
 				TargetPort: intstr.FromString(ironicPortName),
 			},
 		}

--- a/pkg/ironic/secrets_test.go
+++ b/pkg/ironic/secrets_test.go
@@ -173,7 +173,7 @@ password = password
 			User:            "admin",
 			Password:        "password",
 			CurrentHtpasswd: "admin:$2y$05$CJozjmp4SHJjNWcJn1vVsOx4OEBQTDTVTdNFc0I.CVt5xpEZMK4pW",
-			AuthConfig:      strings.Replace(authConfig, "admin", "user", -1),
+			AuthConfig:      strings.ReplaceAll(authConfig, "admin", "user"),
 			ExpectedChanged: true,
 		},
 	}

--- a/pkg/ironic/utils.go
+++ b/pkg/ironic/utils.go
@@ -126,8 +126,6 @@ func getDaemonSetStatus(cctx ControllerContext, deploy *appsv1.DaemonSet) (Statu
 		return inProgress("daemon set not ready yet")
 	}
 
-	var available bool
-
 	// FIXME(dtantsur): the current version of appsv1 does not seem to have
 	// constants for conditions types.
 	// var err error
@@ -140,7 +138,7 @@ func getDaemonSetStatus(cctx ControllerContext, deploy *appsv1.DaemonSet) (Statu
 	// 		return metal3api.IronicStatusProgressing, err
 	// 	}
 	// }
-	available = deploy.Status.NumberUnavailable == 0
+	available := deploy.Status.NumberUnavailable == 0
 
 	if available {
 		return ready()


### PR DESCRIPTION
We don't understand yet how it happened, but the current configuration
is outdated and broken, which is now causing a CI breakage.

This change fixes the configuration, fixes the issues that the linter
now detects and adds a configuration validation step to "make lint".

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
