### PR TITLE
🌱 Functional tests: decrease individual timeouts

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -223,7 +223,7 @@ func WaitForIronic(name types.NamespacedName) *metal3api.Ironic {
 
 		logResources(ironic, "")
 		return false
-	}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
+	}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
 
 	return ironic
 }
@@ -261,7 +261,7 @@ func WaitForUpgrade(name types.NamespacedName, fromVersion, toVersion string) *m
 
 		logResources(ironic, suffix)
 		return false
-	}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
+	}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
 
 	return ironic
 }
@@ -296,7 +296,7 @@ func WaitForIronicFailure(name types.NamespacedName, message string, tolerateRea
 		}
 
 		return true
-	}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
+	}).WithTimeout(90 * time.Second).WithPolling(5 * time.Second).Should(BeTrue())
 
 	return ironic
 }


### PR DESCRIPTION
Provisioning Ironic very rarely takes more than 2 minutes, I'm using
5 minutes just to be safe. Waiting 15 minutes is an overkill, at
this point the process is definitely stuck, and we run the risk of
reaching the overall timeout of 60 minutes.

Wait for a failure even less (1.5 minutes).

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
