### PR TITLE
🌱  Increase test verbosity, create a junit report

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LOGDIR: /tmp/logs
+      JUNIT_OUTPUT: /tmp/logs/report.xml
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Calculate go version
@@ -34,4 +35,10 @@ jobs:
       with:
         name: functional
         path: /tmp/logs/*
+      if: always()
+    - name: Annotate failures
+      uses: mikepenz/action-junit-report@97744eca465b8df9e6e33271cb155003f85327f1 # v5.5.0
+      with:
+        annotate_only: true
+        report_paths: /tmp/logs/report.xml
       if: always()

--- a/test/run.sh
+++ b/test/run.sh
@@ -6,10 +6,11 @@ REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
 cd "${REPO_ROOT}/test"
 
 LOGDIR="${LOGDIR:-/tmp/logs}"
+JUNIT_OUTPUT="${JUNIT_OUTPUT:-${LOGDIR}/report.xml}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-60m}"
 
 . testing.env
 
 mkdir -p "${LOGDIR}"
 
-exec go test -timeout "${TEST_TIMEOUT}"
+exec go test --ginkgo.vv --ginkgo.junit-report "${JUNIT_OUTPUT}" -timeout "${TEST_TIMEOUT}"


### PR DESCRIPTION
Debugging failures is hard with the default verbosity, especially when
a failure in post/pre actions is encountered.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
