### PR TITLE
🐛 Do not clear the installed version when reconciling

### DIFF
--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -183,7 +183,6 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 	}
 
 	newStatus := ironicConf.Status.DeepCopy()
-	newStatus.InstalledVersion = ""
 	requeue = setConditionsFromStatus(cctx, status, &newStatus.Conditions, ironicConf.Generation, "ironic")
 	if !requeue {
 		newStatus.InstalledVersion = actuallyRequestedVersion


### PR DESCRIPTION
The idea was to signal that reconciliation is in progress, but it's
already clear from requestedVersion != installedVersion. Clearing
this field makes it impossible to know which version we're upgrading
from.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
