### PR TITLE
⚠️ Drop DisableRPCHostValidation from the API

### DIFF
--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -179,12 +179,6 @@ type TLS struct {
 	// which may be required for hardware that cannot accept HTTPS links.
 	// +optional
 	DisableVirtualMediaTLS bool `json:"disableVirtualMediaTLS,omitempty"`
-
-	// DisableRPCHostValidation turns off TLS host validation for JSON RPC connections between Ironic instances.
-	// This reduces the security of TLS. Only use if you're unable to provide TLS certificates valid for JSON RPC.
-	// Has no effect if HighAvailability is not set to true.
-	// +optional
-	DisableRPCHostValidation bool `json:"disableRPCHostValidation,omitempty"`
 }
 
 type Images struct {

--- a/config/crd/bases/ironic.metal3.io_ironics.yaml
+++ b/config/crd/bases/ironic.metal3.io_ironics.yaml
@@ -302,12 +302,6 @@ spec:
                     description: CertificateName is a reference to the secret with
                       the TLS certificate.
                     type: string
-                  disableRPCHostValidation:
-                    description: |-
-                      DisableRPCHostValidation turns off TLS host validation for JSON RPC connections between Ironic instances.
-                      This reduces the security of TLS. Only use if you're unable to provide TLS certificates valid for JSON RPC.
-                      Has no effect if HighAvailability is not set to true.
-                    type: boolean
                   disableVirtualMediaTLS:
                     description: |-
                       DisableVirtualMediaTLS turns off TLS on the virtual media server,

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -217,10 +217,6 @@ func buildIronicEnvVars(ironic *metal3api.Ironic, db *metal3api.Database, htpass
 				Name:  "IRONIC_DEPLOYMENT",
 				Value: "Conductor",
 			},
-			{
-				Name:  "IRONIC_INSECURE",
-				Value: strconv.FormatBool(ironic.Spec.TLS.DisableRPCHostValidation),
-			},
 		}...)
 	}
 


### PR DESCRIPTION
There is no TLS support for JSON RPC in the Ironic image,
this option does something not quite relevant.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
