### PR TITLE
🌱 Dont run golangci-lint separately on internal/controller

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,6 @@ jobs:
         working-directory:
         - ""
         - api
-        - internal/controller
         - test
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,6 @@ lint: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) config verify
 	$(GOLANGCI_LINT) run -v ./... --timeout=10m
 	cd api; $(GOLANGCI_LINT) run -v ./... --timeout=10m
-	cd internal/controller; $(GOLANGCI_LINT) run -v ./... --timeout=10m
 	cd test; $(GOLANGCI_LINT) run -v ./... --timeout=10m
 
 .PHONY: bundle


### PR DESCRIPTION
It's not a separate Go module and is linted with the root directory.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
