### PR TITLE
🌱 Enable godot and perfsprint linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,7 +29,7 @@ linters:
   - gochecksumtype
   - goconst
   - gocritic
-  #- godot
+  - godot
   - gofmt
   - goimports
   - goprintffuncname
@@ -53,7 +53,7 @@ linters:
   - noctx
   - nolintlint
   - nosprintfhostport
-  #- perfsprint
+  - perfsprint
   - prealloc
   - predeclared
   - reassign

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -26,16 +26,16 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "ironic.metal3.io", Version: "v1alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = schemeBuilder.AddToScheme
 
-	// Object types we define (including lists)
+	// Object types we define (including lists).
 	objectTypes = []runtime.Object{}
 )
 

--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -20,14 +20,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var (
-	VersionLatest = Version{}
-	Version290    = Version{Major: 29, Minor: 0}
-	Version280    = Version{Major: 28, Minor: 0}
-	Version270    = Version{Major: 27, Minor: 0}
+const (
+	majorVersion28 = 28
+	majorVersion27 = 27
+	majorVersion29 = 29
 )
 
-// Mapping of supported versions to container image tags.
+var (
+	VersionLatest = Version{}
+	Version290    = Version{Major: majorVersion29, Minor: 0}
+	Version280    = Version{Major: majorVersion28, Minor: 0}
+	Version270    = Version{Major: majorVersion27, Minor: 0}
+)
+
+// SupportedVersions is a mapping of supported versions to container image tags.
 // This mapping must be updated each time a new ironic-image branch is created.
 // Also consider updating the version test(s) in test/suite_test.go to verify
 // that the new version is installable and its API version matches
@@ -39,7 +45,7 @@ var SupportedVersions = map[Version]string{
 	Version270:    "release-27.0",
 }
 
-// Inspection defines inspection settings
+// Inspection defines inspection settings.
 type Inspection struct {
 	// Collectors is a list of inspection collectors to enable.
 	// See https://docs.openstack.org/ironic-python-agent/latest/admin/how_it_works.html#inspection-data for details.
@@ -96,7 +102,7 @@ const (
 	IPAddressManagerKeepalived IPAddressManager = "keepalived"
 )
 
-// Networking defines networking settings for Ironic
+// Networking defines networking settings for Ironic.
 type Networking struct {
 	// APIPort is the public port used for Ironic.
 	// +kubebuilder:default=6385
@@ -154,7 +160,7 @@ type Networking struct {
 	MACAddresses []string `json:"macAddresses,omitempty"`
 }
 
-// DeployRamdisk defines IPA ramdisk settings
+// DeployRamdisk defines IPA ramdisk settings.
 type DeployRamdisk struct {
 	// DisableDownloader tells the operator not to start the IPA downloader as the init container.
 	// The user will be responsible for providing the right image to BareMetal Operator.
@@ -240,7 +246,7 @@ type Database struct {
 	TLSCertificateName string `json:"tlsCertificateName,omitempty"`
 }
 
-// IronicSpec defines the desired state of Ironic
+// IronicSpec defines the desired state of Ironic.
 type IronicSpec struct {
 	// APICredentialsName is a reference to the secret with Ironic API credentials.
 	// A new secret will be created if this field is empty.
@@ -279,7 +285,7 @@ type IronicSpec struct {
 	// +optional
 	Images Images `json:"images,omitempty"`
 
-	// Inspection defines inspection settings
+	// Inspection defines inspection settings.
 	// +optional
 	Inspection Inspection `json:"inspection,omitempty"`
 
@@ -304,7 +310,7 @@ type IronicSpec struct {
 	Version string `json:"version,omitempty"`
 }
 
-// IronicStatus defines the observed state of Ironic
+// IronicStatus defines the observed state of Ironic.
 type IronicStatus struct {
 	// Conditions describe the state of the Ironic deployment.
 	// +patchMergeKey=type
@@ -328,7 +334,7 @@ type IronicStatus struct {
 //+kubebuilder:printcolumn:name="Installed Version",type="string",JSONPath=".status.installedVersion",description="Currently installed version"
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Is ready"
 
-// Ironic is the Schema for the ironics API
+// Ironic is the Schema for the ironics API.
 type Ironic struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -339,7 +345,7 @@ type Ironic struct {
 
 //+kubebuilder:object:root=true
 
-// IronicList contains a list of Ironic
+// IronicList contains a list of Ironic.
 type IronicList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/ironicdatabase_types.go
+++ b/api/v1alpha1/ironicdatabase_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// IronicDatabaseSpec defines the desired state of IronicDatabase
+// IronicDatabaseSpec defines the desired state of IronicDatabase.
 type IronicDatabaseSpec struct {
 	// CredentialsName is a reference to the secret with database credentials.
 	// A new secret will be created if this field is empty.
@@ -36,7 +36,7 @@ type IronicDatabaseSpec struct {
 	TLSCertificateName string `json:"tlsCertificateName,omitempty"`
 }
 
-// IronicDatabaseStatus defines the observed state of IronicDatabase
+// IronicDatabaseStatus defines the observed state of IronicDatabase.
 type IronicDatabaseStatus struct {
 	// Conditions describe the state of the Ironic deployment.
 	// +patchMergeKey=type
@@ -63,7 +63,7 @@ type IronicDatabase struct {
 
 //+kubebuilder:object:root=true
 
-// IronicDatabaseList contains a list of IronicDatabase
+// IronicDatabaseList contains a list of IronicDatabase.
 type IronicDatabaseList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/version.go
+++ b/api/v1alpha1/version.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 )
 
-const versionLatestString = "latest"
+const (
+	versionLatestString = "latest"
+)
 
 type Version struct {
 	Major, Minor int

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,8 +61,9 @@ func init() {
 }
 
 const (
-	TLSVersion12 = "TLS12"
-	TLSVersion13 = "TLS13"
+	TLSVersion12       = "TLS12"
+	TLSVersion13       = "TLS13"
+	defaultWebhookPort = 9443
 )
 
 var tlsSupportedVersions = []string{TLSVersion12, TLSVersion13}
@@ -95,7 +96,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port to use for webhooks (0 to disable)")
+	flag.IntVar(&webhookPort, "webhook-port", defaultWebhookPort, "Port to use for webhooks (0 to disable)")
 	flag.StringVar(&watchNamespace, "namespace", os.Getenv("WATCH_NAMESPACE"),
 		"Namespace that the controller watches to reconcile resources.")
 	flag.StringVar(&tlsOptions.TLSMinVersion, "tls-min-version", TLSVersion12,

--- a/config/crd/bases/ironic.metal3.io_ironicdatabases.yaml
+++ b/config/crd/bases/ironic.metal3.io_ironicdatabases.yaml
@@ -40,7 +40,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: IronicDatabaseSpec defines the desired state of IronicDatabase
+            description: IronicDatabaseSpec defines the desired state of IronicDatabase.
             properties:
               credentialsName:
                 description: |-
@@ -56,7 +56,7 @@ spec:
                 type: string
             type: object
           status:
-            description: IronicDatabaseStatus defines the observed state of IronicDatabase
+            description: IronicDatabaseStatus defines the observed state of IronicDatabase.
             properties:
               conditions:
                 description: Conditions describe the state of the Ironic deployment.

--- a/config/crd/bases/ironic.metal3.io_ironics.yaml
+++ b/config/crd/bases/ironic.metal3.io_ironics.yaml
@@ -31,7 +31,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Ironic is the Schema for the ironics API
+        description: Ironic is the Schema for the ironics API.
         properties:
           apiVersion:
             description: |-
@@ -51,7 +51,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: IronicSpec defines the desired state of Ironic
+            description: IronicSpec defines the desired state of Ironic.
             properties:
               apiCredentialsName:
                 description: |-
@@ -160,7 +160,7 @@ spec:
                     type: string
                 type: object
               inspection:
-                description: Inspection defines inspection settings
+                description: Inspection defines inspection settings.
                 properties:
                   collectors:
                     description: |-
@@ -316,7 +316,7 @@ spec:
                 type: string
             type: object
           status:
-            description: IronicStatus defines the observed state of Ironic
+            description: IronicStatus defines the observed state of Ironic.
             properties:
               conditions:
                 description: Conditions describe the state of the Ironic deployment.

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -41,7 +41,7 @@ import (
 	"github.com/metal3-io/ironic-standalone-operator/pkg/ironic"
 )
 
-// IronicReconciler reconciles a Ironic object
+// IronicReconciler reconciles a Ironic object.
 type IronicReconciler struct {
 	client.Client
 	KubeClient  kubernetes.Interface

--- a/internal/controller/ironicdatabase_controller.go
+++ b/internal/controller/ironicdatabase_controller.go
@@ -38,7 +38,7 @@ const (
 	IronicFinalizer string = "ironic.metal3.io"
 )
 
-// IronicDatabaseReconciler reconciles a IronicDatabase object
+// IronicDatabaseReconciler reconciles a IronicDatabase object.
 type IronicDatabaseReconciler struct {
 	client.Client
 	KubeClient  kubernetes.Interface

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -19,7 +19,7 @@ import (
 func ensureFinalizer(cctx ironic.ControllerContext, obj client.Object) (bool, error) {
 	changed := controllerutil.AddFinalizer(obj, IronicFinalizer)
 	if changed {
-		cctx.Logger.Info(fmt.Sprintf("adding finalizer %s", IronicFinalizer))
+		cctx.Logger.Info("adding finalizer " + IronicFinalizer)
 		err := cctx.Client.Update(cctx.Context, obj)
 		if err != nil {
 			return false, fmt.Errorf("failed to add finalizer: %w", err)
@@ -33,7 +33,7 @@ func ensureFinalizer(cctx ironic.ControllerContext, obj client.Object) (bool, er
 func removeFinalizer(cctx ironic.ControllerContext, obj client.Object) (bool, error) {
 	changed := controllerutil.RemoveFinalizer(obj, IronicFinalizer)
 	if changed {
-		cctx.Logger.Info(fmt.Sprintf("removing finalizer %s", IronicFinalizer))
+		cctx.Logger.Info("removing finalizer " + IronicFinalizer)
 		err := cctx.Client.Update(cctx.Context, obj)
 		if err != nil {
 			return false, fmt.Errorf("failed to remove finalizer: %w", err)

--- a/internal/webhook/v1alpha1/ironic_webhook.go
+++ b/internal/webhook/v1alpha1/ironic_webhook.go
@@ -43,7 +43,7 @@ func SetupIronicWebhookWithManager(mgr ctrl.Manager) error {
 
 type IronicCustomValidator struct{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *IronicCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	ironic, ok := obj.(*metal3api.Ironic)
 	if !ok {
@@ -54,7 +54,7 @@ func (r *IronicCustomValidator) ValidateCreate(ctx context.Context, obj runtime.
 	return nil, validation.ValidateIronic(&ironic.Spec, nil)
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *IronicCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	ironic, ok := newObj.(*metal3api.Ironic)
 	if !ok {
@@ -70,7 +70,7 @@ func (r *IronicCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newO
 	return nil, validation.ValidateIronic(&ironic.Spec, &oldIronic.Spec)
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *IronicCustomValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/pkg/ironic/database.go
+++ b/pkg/ironic/database.go
@@ -22,12 +22,12 @@ const (
 )
 
 func databaseDeploymentName(db *metal3api.IronicDatabase) string {
-	return fmt.Sprintf("%s-database", db.Name)
+	return db.Name + "-database"
 }
 
 func DatabaseDNSName(db *metal3api.IronicDatabase, domain string) string {
 	if domain != "" && domain[0] != '.' {
-		domain = fmt.Sprintf(".%s", domain)
+		domain = "." + domain
 	}
 	return fmt.Sprintf("%s.%s.%s%s:%d", databaseDeploymentName(db), db.Namespace, serviceDNSSuffix, domain, databasePort)
 }

--- a/pkg/ironic/ironic.go
+++ b/pkg/ironic/ironic.go
@@ -2,8 +2,8 @@ package ironic
 
 import (
 	"context"
-	"fmt"
 
+	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,12 +11,15 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
 
-	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
+const (
+	defaultExposedPort = 80
+	httpsExposedPort   = 443
 )
 
 func ironicDeploymentName(ironic *metal3api.Ironic) string {
-	return fmt.Sprintf("%s-service", ironic.Name)
+	return ironic.Name + "-service"
 }
 
 func ensureIronicDaemonSet(cctx ControllerContext, ironic *metal3api.Ironic, db *metal3api.Database, apiSecret *corev1.Secret) (Status, error) {
@@ -104,9 +107,9 @@ func ensureIronicService(cctx ControllerContext, ironic *metal3api.Ironic) (Stat
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: ironic.Name, Namespace: ironic.Namespace},
 	}
-	exposedPort := int32(80)
+	exposedPort := int32(defaultExposedPort)
 	if ironic.Spec.TLS.CertificateName != "" {
-		exposedPort = 443
+		exposedPort = httpsExposedPort
 	}
 	result, err := controllerutil.CreateOrUpdate(cctx.Context, cctx.Client, service, func() error {
 		if service.ObjectMeta.Labels == nil {

--- a/pkg/ironic/upgrades.go
+++ b/pkg/ironic/upgrades.go
@@ -12,7 +12,7 @@ import (
 	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
 )
 
-// Leave enough time for potential debugging but don't hold jobs forever
+// Leave enough time for potential debugging but don't hold jobs forever.
 const jobTTLSeconds int32 = 24 * 3600
 
 type upgradePhase string

--- a/pkg/ironic/utils.go
+++ b/pkg/ironic/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -171,13 +172,13 @@ func getJobStatus(cctx ControllerContext, job *batchv1.Job, jobType string) (Sta
 		}
 	}
 
-	messageWithType := fmt.Sprintf("%s job not complete yet", jobType)
+	messageWithType := jobType + " job not complete yet"
 	cctx.Logger.Info(messageWithType, "Job", job.Name, "Conditions", job.Status.Conditions)
 	return inProgress(messageWithType)
 }
 
 func buildEndpoints(ips []string, port int, includeProto string) (endpoints []string) {
-	portString := fmt.Sprint(port)
+	portString := strconv.Itoa(port)
 	for _, ip := range ips {
 		var endpoint string
 		if (includeProto == "https" && port == 443) || (includeProto == "http" && port == 80) {

--- a/pkg/ironic/version.go
+++ b/pkg/ironic/version.go
@@ -11,11 +11,11 @@ const (
 )
 
 var (
-	// NOTE(dtantsur): defaultVersion must be updated after branching
+	// NOTE(dtantsur): defaultVersion must be updated after branching.
 	defaultVersion                = metal3api.VersionLatest
-	defaultMariaDBImage           = fmt.Sprintf("%s/mariadb:latest", defaultRegistry)
-	defaultRamdiskDownloaderImage = fmt.Sprintf("%s/ironic-ipa-downloader:latest", defaultRegistry)
-	defaultKeepalivedImage        = fmt.Sprintf("%s/keepalived:latest", defaultRegistry)
+	defaultMariaDBImage           = defaultRegistry + "/mariadb:latest"
+	defaultRamdiskDownloaderImage = defaultRegistry + "/ironic-ipa-downloader:latest"
+	defaultKeepalivedImage        = defaultRegistry + "/keepalived:latest"
 
 	versionUpgradeScripts = metal3api.Version290
 )

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -62,11 +62,11 @@ import (
 // https://docs.openstack.org/ironic/latest/contributor/webapi-version-history.html
 const (
 	// NOTE(dtantsur): latest is now at least 1.96, so we can rely on this
-	// value to check that specifying Version: 29.0 actually installs 29.0
+	// value to check that specifying Version: 29.0 actually installs 29.0.
 	apiVersionIn270 = "1.94"
 	apiVersionIn280 = "1.95"
 	apiVersionIn290 = "1.96"
-	// Update this periodically to make sure we're installing the latest version by default
+	// Update this periodically to make sure we're installing the latest version by default.
 	knownAPIMinorVersion = 96
 
 	numberOfNodes = 100
@@ -166,7 +166,7 @@ func NewHTTPBasicClient(endpoint string, secret *corev1.Secret) (*gophercloud.Se
 }
 
 func logResources(ironic *metal3api.Ironic, suffix string) {
-	deployName := fmt.Sprintf("%s-service", ironic.Name)
+	deployName := ironic.Name + "-service"
 	if ironic.Spec.HighAvailability {
 		deploy, err := clientset.AppsV1().DaemonSets(ironic.Namespace).Get(ctx, deployName, metav1.GetOptions{})
 		if err == nil {
@@ -559,7 +559,7 @@ func buildIronic(name types.NamespacedName, spec metal3api.IronicSpec) *metal3ap
 func buildDatabase(name types.NamespacedName, credentialsName string) *metal3api.IronicDatabase {
 	result := &metal3api.IronicDatabase{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-db", name.Name),
+			Name:      name.Name + "-db",
 			Namespace: name.Namespace,
 		},
 		Spec: metal3api.IronicDatabaseSpec{
@@ -577,7 +577,7 @@ func buildDatabase(name types.NamespacedName, credentialsName string) *metal3api
 func getDatabaseConnection(name types.NamespacedName) *metal3api.Database {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-api", name.Name),
+			Name:      name.Name + "-api",
 			Namespace: name.Namespace,
 		},
 		Data: map[string][]byte{
@@ -644,7 +644,7 @@ func testUpgrade(ironicVersionOld string, ironicVersionNew string, apiVersionOld
 	ironic = WaitForIronic(name)
 	VerifyIronic(ironic, TestAssumptions{maxAPIVersion: apiVersionOld})
 
-	By(fmt.Sprintf("upgrading to Ironic %s", ironicVersionNew))
+	By("upgrading to Ironic " + ironicVersionNew)
 
 	patch := client.MergeFrom(ironic.DeepCopy())
 	ironic.Spec.Version = ironicVersionNew
@@ -677,7 +677,7 @@ func testUpgradeHA(ironicVersionOld string, ironicVersionNew string, apiVersionO
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-api", name.Name),
+			Name:      name.Name + "-api",
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
@@ -713,7 +713,7 @@ func testUpgradeHA(ironicVersionOld string, ironicVersionNew string, apiVersionO
 	ironic = WaitForIronic(name)
 	VerifyIronic(ironic, TestAssumptions{maxAPIVersion: apiVersionOld})
 
-	By(fmt.Sprintf("upgrading to Ironic %s", ironicVersionNew))
+	By("upgrading to Ironic " + ironicVersionNew)
 
 	patch := client.MergeFrom(ironic.DeepCopy())
 	ironic.Spec.Version = ironicVersionNew
@@ -728,7 +728,7 @@ var _ = Describe("Ironic object tests", func() {
 	var namespace string
 
 	BeforeEach(func() {
-		namespace = fmt.Sprintf("test-%s", CurrentSpecReport().LeafNodeLabels[0])
+		namespace = "test-" + CurrentSpecReport().LeafNodeLabels[0]
 		nsSpec := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 
 		_, err := clientset.CoreV1().Namespaces().Create(ctx, nsSpec, metav1.CreateOptions{})
@@ -790,7 +790,7 @@ var _ = Describe("Ironic object tests", func() {
 
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-api", name.Name),
+				Name:      name.Name + "-api",
 				Namespace: namespace,
 			},
 			Data: map[string][]byte{
@@ -819,7 +819,7 @@ var _ = Describe("Ironic object tests", func() {
 
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-api", name.Name),
+				Name:      name.Name + "-api",
 				Namespace: namespace,
 			},
 			Data: map[string][]byte{


### PR DESCRIPTION
- Enabled the following linters in `.golangci.yaml`:
  - godot
  - perfsprint
 
Fixes #201 
Fixes #206 