### PR TITLE
🌱 Refactor handling secrets on the controller level

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -669,7 +669,7 @@ var _ = Describe("Ironic object tests", func() {
 			DeleteAndWait(ironic)
 		})
 
-		_ = WaitForIronicFailure(name, fmt.Sprintf("API credentials secret %s/banana not found", namespace), false)
+		_ = WaitForIronicFailure(name, fmt.Sprintf("secret %s/banana not found", namespace), false)
 
 		By("creating the secret and recovering the Ironic")
 


### PR DESCRIPTION
Create two new helper functions for readability and future reusing.

Do not use a controller reference for secrets.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
