### PR TITLE
🌱 Use minikube as a cluster type in functional tests

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
+      CLUSTER_TYPE: minikube
       LOGDIR: /tmp/logs
       JUNIT_OUTPUT: /tmp/logs/report.xml
     steps:
@@ -19,10 +20,8 @@ jobs:
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
-    - uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
-      with:
-        cluster_name: kind
-        config: ./test/kind.yaml
+    - name: Setup a minikube cluster
+      uses: medyagh/setup-minikube@cea33675329b799adccc9526aa5daccc26cd5052 # v0.0.19
     - name: Prepare tests
       run: ./test/prepare.sh
     - name: Run tests

--- a/test/prepare.sh
+++ b/test/prepare.sh
@@ -9,6 +9,7 @@ IMG="${IMG:-localhost/controller:test}"
 LOGDIR="${LOGDIR:-/tmp/logs}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-}"
 CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-1.16.1}"
+CLUSTER_TYPE="${CLUSTER_TYPE:-kind}"
 
 . test/testing.env
 
@@ -45,14 +46,22 @@ kind_load() {
 }
 
 for image in ironic mariadb ironic-ipa-downloader; do
-    "${CONTAINER_RUNTIME}" pull "quay.io/metal3-io/${image}"
-    kind_load "quay.io/metal3-io/${image}"
+    if [[ "${CLUSTER_TYPE}" == "kind" ]]; then
+        "${CONTAINER_RUNTIME}" pull "quay.io/metal3-io/${image}"
+        kind_load "quay.io/metal3-io/${image}"
+    else
+        minikube image pull "quay.io/metal3-io/${image}"
+    fi
 done
 
 # Building and installing the operator
 
-"${CONTAINER_RUNTIME}" build -t "${IMG}" . 2>&1 | tee "${LOGDIR}/docker-build.log"
-kind_load "${IMG}"
+if [[ "${CLUSTER_TYPE}" == "kind" ]]; then
+    "${CONTAINER_RUNTIME}" build -t "${IMG}" . 2>&1 | tee "${LOGDIR}/docker-build.log"
+    kind_load "${IMG}"
+else
+    minikube image build -t "${IMG}" . 2>&1 | tee "${LOGDIR}/docker-build.log"
+fi
 make install deploy IMG="${IMG}" DEPLOY_TARGET=testing
 
 kubectl wait --for=condition=Available --timeout=60s \

--- a/test/testing.env
+++ b/test/testing.env
@@ -1,10 +1,17 @@
-# Kind-specific settings to pass into the tests
+CLUSTER_TYPE="${CLUSTER_TYPE:-kind}"
+
 export PROVISIONING_IP="172.22.0.2"
 export PROVISIONING_CIDR="172.22.0.1/24"
 export PROVISIONING_RANGE_BEGIN="172.22.0.10"
 export PROVISIONING_RANGE_END="172.22.0.100"
 export PROVISIONING_INTERFACE="eth0"
-export IRONIC_IP="127.0.0.1"  # our Kind configuration proxies the port 6385
+
+if [[ "${CLUSTER_TYPE}" == "kind" ]]; then
+    export IRONIC_IP="127.0.0.1"  # our Kind configuration proxies the port 6385
+else
+    IRONIC_IP=$(minikube ip)
+    export IRONIC_IP
+fi
 
 export IRONIC_CERT_FILE=/tmp/ironic-tls.crt
 export IRONIC_KEY_FILE=/tmp/ironic-tls.key


### PR DESCRIPTION
MiniKube has more intuitive commands but more importantly allows direct
access to Kubernetes nodes from the host. This will make especially
the HA tests much easier in the future.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
