### PR TITLE
🐛 Mount the MariaDB secret when possible

### DIFF
--- a/pkg/ironic/upgrades.go
+++ b/pkg/ironic/upgrades.go
@@ -37,9 +37,9 @@ func upgradeJobRequired(cctx ControllerContext, ironic *metal3api.Ironic, db *me
 func newMigrationTemplate(cctx ControllerContext, ironic *metal3api.Ironic, database *metal3api.Database, phase upgradePhase) corev1.PodTemplateSpec {
 	script := commandPerPhase[phase]
 
-	volumes, mounts := databaseClientMounts(database)
+	volumes, mounts := databaseClientMounts(cctx, database)
 
-	envVars := databaseClientEnvVars(database)
+	envVars := databaseClientEnvVars(cctx, database)
 	envVars = append(envVars, []corev1.EnvVar{
 		{
 			Name:  "IRONIC_USE_MARIADB",

--- a/pkg/ironic/version.go
+++ b/pkg/ironic/version.go
@@ -17,7 +17,8 @@ var (
 	defaultRamdiskDownloaderImage = fmt.Sprintf("%s/ironic-ipa-downloader:latest", defaultRegistry)
 	defaultKeepalivedImage        = fmt.Sprintf("%s/keepalived:latest", defaultRegistry)
 
-	versionUpgradeScripts = metal3api.Version290
+	versionUpgradeScripts      = metal3api.Version290
+	versionMountDatabaseSecret = metal3api.Version290
 )
 
 type VersionInfo struct {


### PR DESCRIPTION
Passing the password as an environment varible is less secure.
Starting with ironic-image 29.0, a secret mount is accepted.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
