### PR TITLE
🌱 Prepare for multi-node functional tests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -133,3 +133,7 @@ issues:
     - importas
     path: cmd/main.go
     text: metal3iov1alpha1
+  - linters:
+    - gosec
+    path: suite_test.go
+    text: "G404: Use of weak random number generator .*"


### PR DESCRIPTION
This change adapts the testing code for several control plane nodes.
When Kind is not used, the tests now detect which pod is running Ironic.
In the HA scenario, all control plane nodes are assumed to have Ironic.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
