### PR TITLE
🐛 Make sure the API secret can be updated

### DIFF
--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -654,6 +654,7 @@ func newIronicPodTemplate(cctx ControllerContext, ironic *metal3api.Ironic, db *
 				metal3api.IronicAppLabel:     ironicDeploymentName(ironic),
 				metal3api.IronicVersionLabel: cctx.VersionInfo.InstalledVersion.String(),
 			},
+			Annotations: secretVersionAnnotations("api-secret", apiSecret),
 		},
 		Spec: corev1.PodSpec{
 			Containers:     containers,

--- a/pkg/ironic/secrets.go
+++ b/pkg/ironic/secrets.go
@@ -171,3 +171,9 @@ func GenerateSecret(owner *metav1.ObjectMeta, name string, extraFields bool) (*c
 
 	return secret, nil
 }
+
+func secretVersionAnnotations(secretType string, secret *corev1.Secret) map[string]string {
+	return map[string]string{
+		fmt.Sprintf("ironic.metal3.io/%s-version", secretType): fmt.Sprintf("%s/%s", secret.UID, secret.ResourceVersion),
+	}
+}

--- a/pkg/ironic/utils.go
+++ b/pkg/ironic/utils.go
@@ -3,6 +3,7 @@ package ironic
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"sort"
 	"strconv"
@@ -76,8 +77,12 @@ func mergePodTemplates(target *corev1.PodTemplateSpec, source corev1.PodTemplate
 	if target.ObjectMeta.Labels == nil {
 		target.ObjectMeta.Labels = make(map[string]string, len(source.ObjectMeta.Labels))
 	}
-	for k, v := range source.ObjectMeta.Labels {
-		target.ObjectMeta.Labels[k] = v
+	maps.Copy(target.Labels, source.Labels)
+	if source.Annotations != nil {
+		if target.Annotations == nil {
+			target.Annotations = make(map[string]string, len(source.Annotations))
+		}
+		maps.Copy(target.Annotations, source.Annotations)
 	}
 
 	target.Spec.InitContainers = mergeContainers(target.Spec.InitContainers, source.Spec.InitContainers)

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -232,7 +232,7 @@ func WaitForIronic(name types.NamespacedName) *metal3api.Ironic {
 		GinkgoWriter.Printf("Current status of Ironic: %+v\n", ironic.Status)
 
 		cond := meta.FindStatusCondition(ironic.Status.Conditions, string(metal3api.IronicStatusReady))
-		if cond != nil {
+		if cond != nil && cond.ObservedGeneration >= ironic.Generation {
 			expectedVersion := ironic.Spec.Version
 			if expectedVersion != "" {
 				Expect(ironic.Status.RequestedVersion).To(Equal(expectedVersion))
@@ -894,6 +894,19 @@ var _ = Describe("Ironic object tests", func() {
 		ironic.Spec.APICredentialsName = secret.Name
 		err = k8sClient.Patch(ctx, ironic, patch)
 		Expect(err).NotTo(HaveOccurred())
+
+		ironic = WaitForIronic(name)
+		VerifyIronic(ironic, TestAssumptions{apiSecret: secret})
+
+		By("changing the credentials")
+
+		patch = client.MergeFrom(secret.DeepCopy())
+		secret.Data[corev1.BasicAuthPasswordKey] = []byte("new-password")
+		err = k8sClient.Patch(ctx, secret, patch)
+		Expect(err).NotTo(HaveOccurred())
+
+		// NOTE(dtantsur): this check is racy, so make sure the controller has time to catch up
+		time.Sleep(1 * time.Second)
 
 		ironic = WaitForIronic(name)
 		VerifyIronic(ironic, TestAssumptions{apiSecret: secret})


### PR DESCRIPTION
Currently, even though the controller gets a notification,
the containers are not restarted. Add an explicit annotation with
the UID and version of the secret.

Add tests to ensure the behavior.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
