### PR TITLE
⚠️ Drop support for Ironic 27.0 with HA

### DIFF
--- a/pkg/ironic/version.go
+++ b/pkg/ironic/version.go
@@ -17,6 +17,7 @@ var (
 	defaultRamdiskDownloaderImage = defaultRegistry + "/ironic-ipa-downloader:latest"
 	defaultKeepalivedImage        = defaultRegistry + "/keepalived:latest"
 
+	versionWithoutAuthConfig   = metal3api.Version280
 	versionUpgradeScripts      = metal3api.Version290
 	versionMountDatabaseSecret = metal3api.Version290
 )


### PR DESCRIPTION
This allows removing handling of the deprecated auth-config from
the API credentials secret. Nobody should be using 27.0 with HA anyway.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
