### PR TITLE
🐛 Do not create conflicting labels on pods and jobs

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -16,5 +16,6 @@ const (
 var (
 	IronicAppLabel      = IronicLabelPrefix + "/app"
 	IronicDatabaseLabel = IronicLabelPrefix + "/db"
+	IronicServiceLabel  = IronicLabelPrefix + "/ironic"
 	IronicVersionLabel  = IronicLabelPrefix + "/version"
 )

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -652,6 +652,7 @@ func newIronicPodTemplate(cctx ControllerContext, ironic *metal3api.Ironic, db *
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				metal3api.IronicAppLabel:     ironicDeploymentName(ironic),
+				metal3api.IronicServiceLabel: ironic.Name,
 				metal3api.IronicVersionLabel: cctx.VersionInfo.InstalledVersion.String(),
 			},
 		},

--- a/pkg/ironic/ironic.go
+++ b/pkg/ironic/ironic.go
@@ -42,7 +42,7 @@ func ensureIronicDaemonSet(cctx ControllerContext, ironic *metal3api.Ironic, db 
 		if deploy.Labels == nil {
 			deploy.Labels = make(map[string]string, 2)
 		}
-		deploy.Labels[metal3api.IronicAppLabel] = ironicDeploymentName(ironic)
+		deploy.Labels[metal3api.IronicServiceLabel] = ironic.Name
 		deploy.Labels[metal3api.IronicVersionLabel] = cctx.VersionInfo.InstalledVersion.String()
 
 		matchLabels := map[string]string{metal3api.IronicAppLabel: ironicDeploymentName(ironic)}
@@ -80,7 +80,7 @@ func ensureIronicDeployment(cctx ControllerContext, ironic *metal3api.Ironic, db
 		if deploy.Labels == nil {
 			deploy.Labels = make(map[string]string, 2)
 		}
-		deploy.Labels[metal3api.IronicAppLabel] = ironicDeploymentName(ironic)
+		deploy.Labels[metal3api.IronicServiceLabel] = ironic.Name
 		deploy.Labels[metal3api.IronicVersionLabel] = cctx.VersionInfo.InstalledVersion.String()
 
 		matchLabels := map[string]string{metal3api.IronicAppLabel: ironicDeploymentName(ironic)}
@@ -115,9 +115,10 @@ func ensureIronicService(cctx ControllerContext, ironic *metal3api.Ironic) (Stat
 	result, err := controllerutil.CreateOrUpdate(cctx.Context, cctx.Client, service, func() error {
 		if service.ObjectMeta.Labels == nil {
 			cctx.Logger.Info("creating a new ironic service")
-			service.ObjectMeta.Labels = make(map[string]string)
+			service.ObjectMeta.Labels = make(map[string]string, 2)
 		}
-		service.ObjectMeta.Labels[metal3api.IronicAppLabel] = ironicDeploymentName(ironic)
+		service.Labels[metal3api.IronicServiceLabel] = ironic.Name
+		service.Labels[metal3api.IronicVersionLabel] = cctx.VersionInfo.InstalledVersion.String()
 
 		service.Spec.Selector = map[string]string{metal3api.IronicAppLabel: ironicDeploymentName(ironic)}
 		service.Spec.Ports = []corev1.ServicePort{

--- a/pkg/ironic/upgrades.go
+++ b/pkg/ironic/upgrades.go
@@ -77,7 +77,7 @@ func newMigrationTemplate(cctx ControllerContext, ironic *metal3api.Ironic, data
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				metal3api.IronicAppLabel:     ironicDeploymentName(ironic),
+				metal3api.IronicServiceLabel: ironic.Name,
 				metal3api.IronicVersionLabel: cctx.VersionInfo.InstalledVersion.String(),
 			},
 		},
@@ -121,7 +121,7 @@ func ensureIronicUpgradeJob(cctx ControllerContext, ironic *metal3api.Ironic, db
 			cctx.Logger.Info("creating a new upgrade job", "Phase", phase, "From", fromVersion, "To", toVersion.String())
 			job.ObjectMeta.Labels = make(map[string]string, 2)
 		}
-		job.ObjectMeta.Labels[metal3api.IronicAppLabel] = ironicDeploymentName(ironic)
+		job.ObjectMeta.Labels[metal3api.IronicServiceLabel] = ironic.Name
 		job.ObjectMeta.Labels[metal3api.IronicVersionLabel] = cctx.VersionInfo.InstalledVersion.String()
 
 		job.Spec.TTLSecondsAfterFinished = ptr.To(jobTTLSeconds)


### PR DESCRIPTION
Several things got mixed in my mind when writing the upgrade patch.
I intended all resources to have a label mapping them back to Ironic and
its version (for user convenience), but ended up using the label from
the selector of an Ironic deployment/daemonset. Which is clearly a bad
idea.

Create a new label purely for tracking purposes and leave the selector
label only for the pod selector in the deployment/daemonset.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
