### PR TITLE
🌱 Refactoring: group API objects in the new Resources struct

### DIFF
--- a/pkg/ironic/containers_test.go
+++ b/pkg/ironic/containers_test.go
@@ -84,7 +84,8 @@ func TestExpectedContainers(t *testing.T) {
 				Spec: tc.Ironic,
 			}
 
-			podTemplate, err := newIronicPodTemplate(cctx, ironic, nil, secret, "test-domain.example.com")
+			resources := Resources{Ironic: ironic, APISecret: secret}
+			podTemplate, err := newIronicPodTemplate(cctx, resources)
 			if tc.ExpectedError == "" {
 				require.NoError(t, err)
 
@@ -136,7 +137,9 @@ func TestImageOverrides(t *testing.T) {
 	version, err := cctx.VersionInfo.WithIronicOverrides(ironic)
 	require.NoError(t, err)
 	cctx.VersionInfo = version
-	podTemplate, err := newIronicPodTemplate(cctx, ironic, nil, secret, "test-domain.example.com")
+
+	resources := Resources{Ironic: ironic, APISecret: secret}
+	podTemplate, err := newIronicPodTemplate(cctx, resources)
 	require.NoError(t, err)
 
 	images := make(map[string]string, len(expectedImages))
@@ -204,7 +207,8 @@ func TestExpectedExtraEnvVars(t *testing.T) {
 		},
 	}
 
-	podTemplate, err := newIronicPodTemplate(cctx, ironic, nil, secret, "test-domain.example.com")
+	resources := Resources{Ironic: ironic, APISecret: secret}
+	podTemplate, err := newIronicPodTemplate(cctx, resources)
 	require.NoError(t, err)
 
 	extraVars := make(map[string]string, len(expectedExtraVars))

--- a/pkg/ironic/utils.go
+++ b/pkg/ironic/utils.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +35,13 @@ type ControllerContext struct {
 	Logger      logr.Logger
 	Domain      string
 	VersionInfo VersionInfo
+}
+
+type Resources struct {
+	Ironic    *metal3api.Ironic
+	Database  *metal3api.Database
+	APISecret *corev1.Secret
+	TLSSecret *corev1.Secret
 }
 
 func mergeContainers(target, source []corev1.Container) []corev1.Container {

--- a/pkg/ironic/validation.go
+++ b/pkg/ironic/validation.go
@@ -38,7 +38,8 @@ func validateIPinPrefix(ip string, prefix netip.Prefix) error {
 	return nil
 }
 
-func ValidateDHCP(ironic *metal3api.IronicSpec, dhcp *metal3api.DHCP) error {
+func ValidateDHCP(ironic *metal3api.IronicSpec) error {
+	dhcp := ironic.Networking.DHCP
 	hasNetworking := ironic.Networking.IPAddress != "" || ironic.Networking.Interface != "" || len(ironic.Networking.MACAddresses) > 0
 	if !hasNetworking {
 		return errors.New("networking: at least one of ipAddress, interface or macAddresses is required when DHCP is used")
@@ -124,12 +125,12 @@ func ValidateIronic(ironic *metal3api.IronicSpec, old *metal3api.IronicSpec) err
 		return errors.New("networking.ipAddress makes no sense with highly available architecture")
 	}
 
-	if dhcp := ironic.Networking.DHCP; dhcp != nil {
+	if ironic.Networking.DHCP != nil {
 		if ironic.HighAvailability {
 			return errors.New("DHCP support is not implemented in the highly available architecture")
 		}
 
-		if err := ValidateDHCP(ironic, dhcp); err != nil {
+		if err := ValidateDHCP(ironic); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR modifies high-level functions in pkg/ironic to accept a new
Resources structure with Ironic, Database, APISecret and TLSSecret
objects.

The initial thought was to only pass the objects that each function
needs. Unfortunately, higher-level functions need all resources anyway.
Now I need to pass the TLS secret object, which means updating a lot of
functions with a new argument. In this PR, every function that currently
uses the API secret (directly or indirectly) now accepts Resources.

During the refactoring, some redundant arguments have been removed.
E.g. nothing actually used the domain argument passed to some functions.
I'm also removing the assumption that the API secret can be empty (it
cannot, and it has been this way for a while).

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
