### PR TITLE
🐛 Do not requeue while waiting for external events

### DIFF
--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -192,8 +192,9 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 	}
 
 	newStatus := ironicConf.Status.DeepCopy()
-	requeue = setConditionsFromStatus(cctx, status, &newStatus.Conditions, ironicConf.Generation, "ironic")
-	if !requeue {
+	setConditionsFromStatus(cctx, status, &newStatus.Conditions, ironicConf.Generation, "ironic")
+	requeue = status.NeedsRequeue()
+	if status.IsReady() {
 		newStatus.InstalledVersion = actuallyRequestedVersion
 	}
 

--- a/internal/controller/ironicdatabase_controller.go
+++ b/internal/controller/ironicdatabase_controller.go
@@ -123,7 +123,8 @@ func (r *IronicDatabaseReconciler) handleDatabase(cctx ironic.ControllerContext,
 		return
 	}
 
-	requeue = setConditionsFromStatus(cctx, status, &newStatus.Conditions, db.Generation, "database")
+	setConditionsFromStatus(cctx, status, &newStatus.Conditions, db.Generation, "database")
+	requeue = status.NeedsRequeue()
 
 	if !apiequality.Semantic.DeepEqual(newStatus, &db.Status) {
 		cctx.Logger.Info("updating status", "Status", newStatus)

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -123,7 +123,7 @@ func updateSecretOwners(cctx ironic.ControllerContext, ironicConf *metal3api.Iro
 	return false, nil
 }
 
-func setConditionsFromStatus(cctx ironic.ControllerContext, status ironic.Status, conditions *[]metav1.Condition, generation int64, resource string) (requeue bool) {
+func setConditionsFromStatus(cctx ironic.ControllerContext, status ironic.Status, conditions *[]metav1.Condition, generation int64, resource string) {
 	message := fmt.Sprintf("%s: %s", resource, status)
 
 	if !status.IsReady() {
@@ -135,11 +135,9 @@ func setConditionsFromStatus(cctx ironic.ControllerContext, status ironic.Status
 		cctx.Logger.Info(status.String())
 		setCondition(cctx, conditions, generation, metal3api.IronicStatusReady, false, reason, message)
 
-		requeue = status.Fatal == nil
 		return
 	}
 
 	setCondition(cctx, conditions, generation,
 		metal3api.IronicStatusReady, true, metal3api.IronicReasonAvailable, message)
-	return
 }


### PR DESCRIPTION
The operator is going to be notified via its ownership of Deployments,
DaemonSets and Jobs.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
