### PR TITLE
🐛 Fix detection of a completed Deployment

### DIFF
--- a/pkg/ironic/utils.go
+++ b/pkg/ironic/utils.go
@@ -115,7 +115,7 @@ func getDeploymentStatus(cctx ControllerContext, deploy *appsv1.Deployment) (Sta
 				err := fmt.Errorf("deployment stopped progressing: %s", cond.Message)
 				return Status{Fatal: err}, nil
 			}
-			updated = cond.Reason == "NewReplicaSetAvailable"
+			updated = cond.Reason == "NewReplicaSetAvailable" && deploy.Status.UpdatedReplicas >= deploy.Status.Replicas
 		}
 		if cond.Type == appsv1.DeploymentAvailable && cond.Status == corev1.ConditionTrue {
 			available = true


### PR DESCRIPTION
Per somewhat hidden documentation [1], we must inspect the Progressing
condition and its Reason. Available is still True directly after an update
because the old replica is still running.

On top of that, stop reconciliation with a fatal error when the
deployment no longer progresses.

Unfortunately, client-go does not expose the necessary Reason constants,
so I have to hardcode them based on the values from the documentation
and real-world testing.

[1] https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
