### PR TITLE
🌱 Tests: only collect logs from existing containers and IPs from active pods

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -395,7 +395,9 @@ func getCurrentIronicIPs(ctx context.Context, namespace, name string) []string {
 	addresses := make([]string, 0, len(pods.Items))
 	for _, pod := range pods.Items {
 		// Only use one address per pod, no need for both IP families
-		addresses = append(addresses, pod.Status.HostIP)
+		if pod.Status.Phase == corev1.PodRunning {
+			addresses = append(addresses, pod.Status.HostIP)
+		}
 	}
 	return addresses
 }
@@ -588,7 +590,10 @@ func CollectLogs(namespace string) {
 
 		writeYAML(&pod, namespace, pod.Name, "pod")
 
-		for _, cont := range pod.Spec.Containers {
+		for _, cont := range pod.Status.ContainerStatuses {
+			writeContainerLogs(&pod, cont.Name, logDir)
+		}
+		for _, cont := range pod.Status.InitContainerStatuses {
 			writeContainerLogs(&pod, cont.Name, logDir)
 		}
 	}


### PR DESCRIPTION
Multinode tests may end up with a few pods that fail to schedule. These
don't have container logs, which causes the logs collection to fail.

Similarly, we end up with empty IP addresses if we collect HostIPs from
such pods. Just ignore them.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
