### PR TITLE
:seedling: Enable unparam linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -67,7 +67,7 @@ linters:
   - tparallel
   - typecheck
   - unconvert
-  #- unparam
+  - unparam
   - unused
   - usestdlibvars
   - usetesting

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -44,11 +44,12 @@ func removeFinalizer(cctx ironic.ControllerContext, obj client.Object) (bool, er
 	return false, nil
 }
 
-func setCondition(cctx ironic.ControllerContext, conditions *[]metav1.Condition, generation int64, status metal3api.IronicStatusConditionType, value bool, reason, message string) {
+func setCondition(conditions *[]metav1.Condition, generation int64, value bool, reason, message string) {
 	condStatus := metav1.ConditionFalse
 	if value {
 		condStatus = metav1.ConditionTrue
 	}
+	status := metal3api.IronicStatusReady
 	cond := metav1.Condition{
 		Type:               string(status),
 		Status:             condStatus,
@@ -133,11 +134,10 @@ func setConditionsFromStatus(cctx ironic.ControllerContext, status ironic.Status
 		}
 
 		cctx.Logger.Info(status.String())
-		setCondition(cctx, conditions, generation, metal3api.IronicStatusReady, false, reason, message)
+		setCondition(conditions, generation, false, reason, message)
 
 		return
 	}
 
-	setCondition(cctx, conditions, generation,
-		metal3api.IronicStatusReady, true, metal3api.IronicReasonAvailable, message)
+	setCondition(conditions, generation, true, metal3api.IronicReasonAvailable, message)
 }

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -445,7 +445,7 @@ func buildDNSIP(dhcp *metal3api.DHCP) string {
 	return ""
 }
 
-func newURLProbeHandler(ironic *metal3api.Ironic, https bool, port int, path string, requiresOk bool) corev1.ProbeHandler {
+func newURLProbeHandler(https bool, port int, path string, requiresOk bool) corev1.ProbeHandler {
 	proto := "http"
 	if https {
 		proto = "https"
@@ -578,9 +578,9 @@ func newIronicPodTemplate(cctx ControllerContext, resources Resources) (corev1.P
 
 	ironicPorts, httpdPorts := buildIronicHttpdPorts(resources.Ironic)
 
-	ironicHandler := newURLProbeHandler(resources.Ironic, resources.TLSSecret != nil, int(resources.Ironic.Spec.Networking.APIPort), "/v1", true)
+	ironicHandler := newURLProbeHandler(resources.TLSSecret != nil, int(resources.Ironic.Spec.Networking.APIPort), "/v1", true)
 	httpPathExpected := !resources.Ironic.Spec.DeployRamdisk.DisableDownloader
-	httpdHandler := newURLProbeHandler(resources.Ironic, false, int(resources.Ironic.Spec.Networking.ImageServerPort), knownExistingPath, httpPathExpected)
+	httpdHandler := newURLProbeHandler(false, int(resources.Ironic.Spec.Networking.ImageServerPort), knownExistingPath, httpPathExpected)
 
 	containers := []corev1.Container{
 		{


### PR DESCRIPTION
This PR:
* Enable unparam linter
* Address issues related with unused params in some functions

Fixes: #209 