### PR TITLE
✨ Promote the HighAvailability feature gate to Beta status

### DIFF
--- a/api/v1alpha1/features.go
+++ b/api/v1alpha1/features.go
@@ -11,7 +11,7 @@ const (
 
 var (
 	availableFeatures = map[featuregate.Feature]featuregate.FeatureSpec{
-		FeatureHighAvailability: {Default: false, PreRelease: featuregate.Alpha},
+		FeatureHighAvailability: {Default: false, PreRelease: featuregate.Beta},
 	}
 
 	CurrentFeatureGate = featuregate.NewFeatureGate()

--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -285,7 +285,7 @@ type IronicSpec struct {
 	// HighAvailability causes Ironic to be deployed as a DaemonSet on control plane nodes instead of a deployment with 1 replica.
 	// Requires database to be installed and linked to DatabaseName.
 	// DHCP support is not yet implemented in the highly available architecture.
-	// EXPERIMENTAL: do not use, the implementation is incomplete.
+	// Requires the HighAvailability feature gate to be set.
 	// +optional
 	HighAvailability bool `json:"highAvailability,omitempty"`
 

--- a/config/crd/bases/ironic.metal3.io_ironics.yaml
+++ b/config/crd/bases/ironic.metal3.io_ironics.yaml
@@ -134,7 +134,7 @@ spec:
                   HighAvailability causes Ironic to be deployed as a DaemonSet on control plane nodes instead of a deployment with 1 replica.
                   Requires database to be installed and linked to DatabaseName.
                   DHCP support is not yet implemented in the highly available architecture.
-                  EXPERIMENTAL: do not use, the implementation is incomplete.
+                  Requires the HighAvailability feature gate to be set.
                 type: boolean
               images:
                 description: Images is a collection of container images to deploy


### PR DESCRIPTION
With the recent fixes and CI additions, this feature should be safe
to test by the wider audience. It's still disabled by default.

As a reminder, only virtual media is supported in HA mode for now.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
