### PR TITLE
🌱 Tests: repair tests when using Kind

### DIFF
--- a/test/kind.yaml
+++ b/test/kind.yaml
@@ -12,3 +12,6 @@ nodes:
   - containerPort: 6385
     hostPort: 6385
     listenAddress: "127.0.0.1"
+  - containerPort: 8089
+    hostPort: 8089
+    listenAddress: "127.0.0.1"


### PR DESCRIPTION
We should get rid of Kind support eventually, but mariadb-image still
uses it.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
