### PR TITLE
🌱 Test: shorten the pod status printed to stdout

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -225,7 +225,20 @@ func logResources(ironic *metal3api.Ironic, suffix string) {
 	Expect(err).NotTo(HaveOccurred())
 
 	for _, pod := range pods.Items {
-		GinkgoWriter.Printf("... status of pod %s: %+v\n", pod.Name, pod.Status)
+		var notReady []string
+		if pod.Status.Phase != corev1.PodSucceeded {
+			for _, cont := range pod.Status.InitContainerStatuses {
+				if !cont.Ready {
+					notReady = append(notReady, cont.Name)
+				}
+			}
+			for _, cont := range pod.Status.ContainerStatuses {
+				if !cont.Ready {
+					notReady = append(notReady, cont.Name)
+				}
+			}
+		}
+		GinkgoWriter.Printf("... status of pod %s: %s, not ready: %+v\n", pod.Name, pod.Status.Phase, notReady)
 	}
 }
 

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -544,7 +544,6 @@ func VerifyIronic(ironic *metal3api.Ironic, assumptions TestAssumptions) {
 	By("checking the service")
 
 	svc, err := clientset.CoreV1().Services(ironic.Namespace).Get(ctx, ironic.Name, metav1.GetOptions{})
-	GinkgoWriter.Printf("Ironic service: %+v\n", svc)
 	Expect(err).NotTo(HaveOccurred())
 
 	writeYAML(svc, svc.Namespace, svc.Name, "service")


### PR DESCRIPTION
Pod status are very long, printing all of them makes the output
unreadable and may overflow disk space on a github worker.

Only print the pod phase and the containers that are not ready.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
