### PR TITLE
:seedling: change functional test to run on larger runner

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       CLUSTER_TYPE: minikube
       LOGDIR: /tmp/logs


### PR DESCRIPTION
ubuntu-latest has only 14gb of space, ubuntu-latest-4-cores should have 100gb. This flavor is used for BMO e2e as well.