### PR TITLE
🌱 Split the functional test into upgrades and regular tests

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -11,6 +11,13 @@ jobs:
       CLUSTER_TYPE: minikube
       LOGDIR: /tmp/logs
       JUNIT_OUTPUT: /tmp/logs/report.xml
+    strategy:
+      matrix:
+        include:
+          - name: "upgrade"
+            label_filter: "upgrade"
+          - name: "regular"
+            label_filter: "!upgrade"
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Calculate go version
@@ -28,13 +35,15 @@ jobs:
       run: ./test/prepare.sh
     - name: Run tests
       run: ./test/run.sh
+      env:
+        LABEL_FILTER: "${{ matrix.label_filter }}"
     - name: Collect logs
       run: ./test/collect-logs.sh
       if: always()
     - name: Upload logs artifacts
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: functional
+        name: functional-${{ matrix.name }}
         path: /tmp/logs/*
       if: always()
     - name: Annotate failures

--- a/test/run.sh
+++ b/test/run.sh
@@ -8,7 +8,6 @@ cd "${REPO_ROOT}/test"
 LOGDIR="${LOGDIR:-/tmp/logs}"
 JUNIT_OUTPUT="${JUNIT_OUTPUT:-${LOGDIR}/report.xml}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-90m}"
-EXTRA_ARGS="${EXTRA_ARGS:-}"
 
 . testing.env
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -8,9 +8,16 @@ cd "${REPO_ROOT}/test"
 LOGDIR="${LOGDIR:-/tmp/logs}"
 JUNIT_OUTPUT="${JUNIT_OUTPUT:-${LOGDIR}/report.xml}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-90m}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
 
 . testing.env
 
 mkdir -p "${LOGDIR}"
 
-exec go test --ginkgo.vv --ginkgo.junit-report "${JUNIT_OUTPUT}" -timeout "${TEST_TIMEOUT}"
+declare -a EXTRA_ARGS
+if [[ -n "${LABEL_FILTER:-}" ]]; then
+    EXTRA_ARGS=(--ginkgo.label-filter "${LABEL_FILTER}")
+fi
+
+exec go test --ginkgo.vv --ginkgo.junit-report "${JUNIT_OUTPUT}" -timeout "${TEST_TIMEOUT}" \
+    --ginkgo.fail-on-empty "${EXTRA_ARGS[@]}"

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -1077,19 +1077,19 @@ var _ = Describe("Ironic object tests", func() {
 		VerifyIronic(ironic, TestAssumptions{withTLS: true})
 	})
 
-	It("creates Ironic 27.0 and upgrades to 28.0", Label("v270-to-280"), func() {
+	It("creates Ironic 27.0 and upgrades to 28.0", Label("v270-to-280", "upgrade"), func() {
 		testUpgrade("27.0", "28.0", apiVersionIn270, apiVersionIn280, namespace)
 	})
 
-	It("creates Ironic 28.0 and upgrades to 29.0", Label("v280-to-290"), func() {
+	It("creates Ironic 28.0 and upgrades to 29.0", Label("v280-to-290", "upgrade"), func() {
 		testUpgrade("28.0", "29.0", apiVersionIn280, apiVersionIn290, namespace)
 	})
 
-	It("creates Ironic 29.0 and upgrades to latest", Label("v290-to-latest"), func() {
+	It("creates Ironic 29.0 and upgrades to latest", Label("v290-to-latest", "upgrade"), func() {
 		testUpgrade("29.0", "latest", apiVersionIn290, "", namespace)
 	})
 
-	It("refuses to downgrade Ironic with a database", Label("no-db-downgrade"), func() {
+	It("refuses to downgrade Ironic with a database", Label("no-db-downgrade", "upgrade"), func() {
 		if customImage != "" || customImageVersion != "" {
 			Skip("skipping because a custom image is provided")
 		}
@@ -1123,11 +1123,11 @@ var _ = Describe("Ironic object tests", func() {
 		WaitForIronicFailure(name, "Ironic does not support downgrades", true)
 	})
 
-	It("creates Ironic 28.0 with HA and upgrades to 29.0", Label("ha-v280-to-v290"), func() {
+	It("creates Ironic 28.0 with HA and upgrades to 29.0", Label("ha-v280-to-v290", "ha", "upgrade"), func() {
 		testUpgradeHA("28.0", "29.0", apiVersionIn280, apiVersionIn290, namespace)
 	})
 
-	It("creates Ironic 29.0 with HA and upgrades to latest", Label("ha-v290-to-latest"), func() {
+	It("creates Ironic 29.0 with HA and upgrades to latest", Label("ha-v290-to-latest", "ha", "upgrade"), func() {
 		testUpgradeHA("29.0", "latest", apiVersionIn290, "", namespace)
 	})
 
@@ -1160,7 +1160,7 @@ var _ = Describe("Ironic object tests", func() {
 		VerifyIronic(ironic, TestAssumptions{})
 	})
 
-	It("creates highly available Ironic", Label("ha-no-params"), func() {
+	It("creates highly available Ironic", Label("ha-no-params", "ha"), func() {
 		name := types.NamespacedName{
 			Name:      "test-ironic",
 			Namespace: namespace,
@@ -1181,7 +1181,7 @@ var _ = Describe("Ironic object tests", func() {
 		VerifyIronic(ironic, TestAssumptions{withHA: true})
 	})
 
-	It("creates highly available Ironic with TLS and credentials", Label("ha-tls-api-secret"), func() {
+	It("creates highly available Ironic with TLS and credentials", Label("ha-tls-api-secret", "ha"), func() {
 		name := types.NamespacedName{
 			Name:      "test-ironic",
 			Namespace: namespace,


### PR DESCRIPTION
The tests are pretty long, especially the upgrade ones. Splitting them
into a new job will allow for a faster CI and will hopefully avoid
running out of resources in the future.

The patch adds tags "ha" and "upgrade" to all tests where applicable.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
