### PR TITLE
:seedling: add link checker workflow

### DIFF
--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -1,0 +1,14 @@
+name: PR Check Links
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  check-pr-links:
+    uses: metal3-io/project-infra/.github/workflows/pr-link-check.yml@main
+    with:
+      upstream: https://github.com/metal3-io/ironic-standalone-operator.git

--- a/.github/workflows/scheduled-link-check.yml
+++ b/.github/workflows/scheduled-link-check.yml
@@ -1,0 +1,17 @@
+name: Scheduled Link Check
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: "0 0 15 * *"
+  repository_dispatch:
+    # run manually
+    types: [check-links]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-links:
+    uses: metal3-io/project-infra/.github/workflows/scheduled-link-check.yml@main

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,7 +45,7 @@ Ironic is the Schema for the ironics API.
       <td>true</td>
       </tr>
       <tr>
-      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta">metadata</a></b></td>
       <td>object</td>
       <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
       <td>true</td>

--- a/hack/gen-api-doc.sh
+++ b/hack/gen-api-doc.sh
@@ -9,3 +9,7 @@ CRDOC_VERSION="0.6.2@sha256:355ef777a45021ee864e613b2234b4f2c6193762e3e0de94a26b
     ghcr.io/fybrik/crdoc:"${CRDOC_VERSION}" \
     --resources /src/config/crd/bases/ --output /dev/stdout \
     > docs/api.md
+
+# FIXME: crdoc generates links to old k8s documentation, link checker complains
+sed -i -e 's#/v1.20/#/v1.32/#' docs/api.md
+


### PR DESCRIPTION
Add link checker workflow, so it gets replicated to soon-to-be-created release branches as well. Schedule runs on 15th of each month.

The one link to be fixed is auto-generated by a job, so it needs to be fixed in the job each time until the generation is fixed. I'll leave the generator fixing to another commit.