### PR TITLE
:seedling: clean up obsolete release variables from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,11 +309,6 @@ go-version: ## Print the go version we use to compile our binaries and images
 ## Release
 ## --------------------------------------
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
-ifneq (,$(findstring -,$(RELEASE_TAG)))
-    PRE_RELEASE=true
-endif
-# the previous release tag, e.g., v1.7.0, excluding pre-release tags
-PREVIOUS_TAG ?= $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | sort -V | grep -B1 $(RELEASE_TAG) | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | head -n 1 2>/dev/null)
 RELEASE_NOTES_DIR := releasenotes
 
 $(RELEASE_NOTES_DIR):


### PR DESCRIPTION
We're actually not using these variables with the new Go based release note generator, the logic is all built-in to the binary.