### PR TITLE
🐛 Set podReplacementPolicy on upgrade jobs

### DIFF
--- a/pkg/ironic/upgrades.go
+++ b/pkg/ironic/upgrades.go
@@ -140,6 +140,7 @@ func ensureIronicUpgradeJob(cctx ControllerContext, resources Resources, phase u
 
 		job.Spec.TTLSecondsAfterFinished = ptr.To(jobTTLSeconds)
 		mergePodTemplates(&job.Spec.Template, template)
+		job.Spec.PodReplacementPolicy = ptr.To(batchv1.Failed)
 
 		return controllerutil.SetControllerReference(resources.Ironic, job, cctx.Scheme)
 	})


### PR DESCRIPTION
This is an attempt to fix one of the issues reported in #297, making
sure no upgrade processes can run in parallel.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
