### PR TITLE
🌱 Tests: better logs collection for upgrade debugging

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -543,7 +543,11 @@ func writeContainerLogs(pod *corev1.Pod, containerName, logDir string) {
 	podLogOpts := corev1.PodLogOptions{Container: containerName}
 	req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOpts)
 	podLogs, err := req.Stream(ctx)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		// Not fatal in many cases, report and move on
+		GinkgoWriter.Printf("Warning: logs not available for pod %s container %s: %s\n", pod.Name, containerName, err)
+		return
+	}
 	defer podLogs.Close()
 
 	targetFileName := fmt.Sprintf("%s/%s.log", logDir, containerName)


### PR DESCRIPTION
Something strange is happening in the upgrade jobs, and the current logs
don't provide enough clue, so:
- collect logs on every iteration instead of only at the end
- collect ReplicaSets as well
- sort Events by CreationTimestamp to make the result readable
- collect more resources from each namespace
- collect pods from kube-system

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
