### PR TITLE
🌱 Tests: increase the timeout in upgrade tests

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -263,7 +263,7 @@ func WaitForUpgrade(name types.NamespacedName, toVersion string) *metal3api.Iron
 
 		logResources(ironic, suffix)
 		return false
-	}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
+	}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
 
 	return ironic
 }


### PR DESCRIPTION
It seems that the HA tests sometime just slightly exceed the current 5
minutes. It's expected that HA upgrades take a bit longer than an
installation since the daemon set updates replicas sequentially.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>