### PR TITLE
🌱 Revert "Tests: increase the node testing timeout for the non-HA case"

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -555,12 +555,7 @@ func VerifyIronic(ironic *metal3api.Ironic, assumptions TestAssumptions) {
 
 	By("creating and deleting a lot of Nodes")
 
-	newTimeout := 2 * time.Minute
-	if !assumptions.withHA {
-		// FIXME(dtantsur): the non-HA (most likely, no database) case has regressed in performance after the eventlet migration.
-		newTimeout = 5 * time.Minute
-	}
-	withTimeout, cancel = context.WithTimeout(ctx, newTimeout)
+	withTimeout, cancel = context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
 	stressTest(withTimeout, clients)


### PR DESCRIPTION
The performance regression has been fixed in Ironic, and more fixes are
on the way. Let us revert to the previous timeouts to not miss any
future regressions.

This partly reverts commit fe0f5fcbfbbae3f8831ce5fd5963c9b2129a9618
(the added tests are not deleted).

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
