### PR TITLE
🌱 Export IPA_BASEURI to have stable tests

### DIFF
--- a/config/testing/kustomization.yaml
+++ b/config/testing/kustomization.yaml
@@ -2,4 +2,4 @@ resources:
 - ../default
 
 patches:
-- path: manager_feature_gates_patch.yaml
+- path: manager_irso_config_patch.yaml

--- a/config/testing/manager_irso_config_patch.yaml
+++ b/config/testing/manager_irso_config_patch.yaml
@@ -11,3 +11,5 @@ spec:
           env:
             - name: FEATURE_GATES
               value: HighAvailability=true,Overrides=true
+            - name: IPA_BASEURI
+              value: https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"net/netip"
+	"os"
 	"strconv"
 	"strings"
 
@@ -558,6 +559,8 @@ func newIronicPodTemplate(cctx ControllerContext, resources Resources) (corev1.P
 	var ipaDownloaderVars []corev1.EnvVar
 	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
 		"IPA_BRANCH", cctx.VersionInfo.AgentBranch)
+	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
+		"IPA_BASEURI", os.Getenv("IPA_BASEURI"))
 
 	volumes, mounts := buildIronicVolumesAndMounts(cctx, resources)
 	sharedVolumeMount := mounts[0]


### PR DESCRIPTION
We have seen flaky test where it was taking long time to download IPA images and causing failure in the test. The addition of the IPA_BASEURI var in the test could fix the flaky behavior.

Failed Test: We can check the ramdix downloader file in logs. We can see it was timedout after 30 minutes and trying to download from opendev link.
https://github.com/metal3-io/ironic-standalone-operator/actions/runs/17063752211/job/48478369021
