### PR TITLE
⚠️ Move the JSON RPC port from 8089 to 6189

### DIFF
--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -164,6 +164,13 @@ type Networking struct {
 	// Only set if no other options can be used.
 	// +optional
 	MACAddresses []string `json:"macAddresses,omitempty"`
+
+	// RPCPort is the internal RPC port used for Ironic.
+	// Only change this if the default value causes a conflict on your deployment.
+	// +kubebuilder:default=6189
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	RPCPort int32 `json:"rpcPort,omitempty"`
 }
 
 // DeployRamdisk defines IPA ramdisk settings.

--- a/config/crd/bases/ironic.metal3.io_ironics.yaml
+++ b/config/crd/bases/ironic.metal3.io_ironics.yaml
@@ -278,6 +278,14 @@ spec:
                     items:
                       type: string
                     type: array
+                  rpcPort:
+                    default: 6189
+                    description: |-
+                      RPCPort is the internal RPC port used for Ironic.
+                      Only change this if the default value causes a conflict on your deployment.
+                    format: int32
+                    minimum: 1
+                    type: integer
                 type: object
               nodeSelector:
                 additionalProperties:

--- a/docs/api.md
+++ b/docs/api.md
@@ -508,6 +508,18 @@ Warning: keepalived is not compatible with the highly available architecture.<br
 Only set if no other options can be used.<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>rpcPort</b></td>
+        <td>integer</td>
+        <td>
+          RPCPort is the internal RPC port used for Ironic.
+Only change this if the default value causes a conflict on your deployment.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Default</i>: 6189<br/>
+            <i>Minimum</i>: 1<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -210,6 +210,12 @@ func buildIronicEnvVars(cctx ControllerContext, resources Resources) []corev1.En
 			Name:  "IRONIC_EXPOSE_JSON_RPC",
 			Value: strconv.FormatBool(resources.Ironic.Spec.HighAvailability),
 		},
+		// NOTE(dtantsur): this is necessary for the transition process from port 8089 (conflicting with kubernetes-nmstate)
+		// to port 6189 chosen for Metal3.
+		{
+			Name:  "OS_JSON_RPC__PORT",
+			Value: "8089",
+		},
 	}...)
 
 	if resources.Ironic.Spec.Database != nil {

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -214,7 +214,7 @@ func buildIronicEnvVars(cctx ControllerContext, resources Resources) []corev1.En
 		// to port 6189 chosen for Metal3.
 		{
 			Name:  "OS_JSON_RPC__PORT",
-			Value: "8089",
+			Value: strconv.Itoa(int(resources.Ironic.Spec.Networking.RPCPort)),
 		},
 	}...)
 

--- a/pkg/ironic/containers_test.go
+++ b/pkg/ironic/containers_test.go
@@ -175,7 +175,7 @@ func TestExpectedExtraEnvVars(t *testing.T) {
 		"OS_CONDUCTOR__DEPLOY_CALLBACK_TIMEOUT": "4800",
 		"OS_CONDUCTOR__INSPECT_TIMEOUT":         "1800",
 		// This is currently set unconditionally by IrSO itself and will eventually be replaced by a proper ironic-image variable.
-		"OS_JSON_RPC__PORT": "8089",
+		"OS_JSON_RPC__PORT": "6189",
 	}
 
 	ironic := &metal3api.Ironic{
@@ -188,6 +188,7 @@ func TestExpectedExtraEnvVars(t *testing.T) {
 				Interface:        "eth0",
 				IPAddress:        "192.0.2.2",
 				IPAddressManager: metal3api.IPAddressManagerKeepalived,
+				RPCPort:          6189,
 			},
 			ExtraConfig: []metal3api.ExtraConfig{
 				{

--- a/pkg/ironic/containers_test.go
+++ b/pkg/ironic/containers_test.go
@@ -174,6 +174,8 @@ func TestExpectedExtraEnvVars(t *testing.T) {
 		"OS_PXE__BOOT_RETRY_TIMEOUT":            "1200",
 		"OS_CONDUCTOR__DEPLOY_CALLBACK_TIMEOUT": "4800",
 		"OS_CONDUCTOR__INSPECT_TIMEOUT":         "1800",
+		// This is currently set unconditionally by IrSO itself and will eventually be replaced by a proper ironic-image variable.
+		"OS_JSON_RPC__PORT": "8089",
 	}
 
 	ironic := &metal3api.Ironic{

--- a/test/kind.yaml
+++ b/test/kind.yaml
@@ -12,6 +12,6 @@ nodes:
   - containerPort: 6385
     hostPort: 6385
     listenAddress: "127.0.0.1"
-  - containerPort: 8089
-    hostPort: 8089
+  - containerPort: 6189
+    hostPort: 6189
     listenAddress: "127.0.0.1"

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -440,7 +440,7 @@ func verifyRPC(ctx context.Context, ironicIPs []string, withTLS bool) {
 		if withTLS {
 			proto = "https://"
 		}
-		testURL := proto + net.JoinHostPort(ironicIP, "8089")
+		testURL := proto + net.JoinHostPort(ironicIP, "6189")
 		statusCode := helpers.GetStatusCode(ctx, &httpClient, testURL)
 		Expect(statusCode).To(Equal(401))
 	}


### PR DESCRIPTION
The port 8089 conflicts with kubernetes-nmstate, and is generally quite
risky because of the 808* range. We have chosen a new port from the same
618* range we use for httpd.

A quick internet search revealed no known users of port 6189. A query to
Gemini revealed a malware that was used around 2010 but has all but
disappeared by now.

A new API is added to modify the port in case of future conflicts.

See-also: https://github.com/metal3-io/ironic-image/pull/741
Closes: #245 
Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>