### PR TITLE
:seedling: Enable variable shadowing check in govet linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -114,6 +114,9 @@ linters-settings:
     case:
       rules:
         json: goCamel
+  govet:
+    enable:
+    - shadow
 issues:
   exclude-files:
   - "zz_generated.*\\.go$"

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -126,7 +126,8 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 	if actuallyRequestedVersion != ironicConf.Status.InstalledVersion && actuallyRequestedVersion != ironicConf.Status.RequestedVersion {
 		// Ironic does not support downgrades when a real external database is used.
 		if ironicConf.Status.InstalledVersion != "" && ironicConf.Spec.Database != nil {
-			parsedVersion, err := metal3api.ParseVersion(ironicConf.Status.InstalledVersion)
+			var parsedVersion metal3api.Version
+			parsedVersion, err = metal3api.ParseVersion(ironicConf.Status.InstalledVersion)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/ironic/ironic.go
+++ b/pkg/ironic/ironic.go
@@ -169,7 +169,8 @@ func EnsureIronic(cctx ControllerContext, resources Resources) (status Status, e
 	}
 
 	if resources.Ironic.Spec.Database != nil {
-		jobStatus, err := ensureIronicUpgradeJob(cctx, resources, preUpgrade)
+		var jobStatus Status
+		jobStatus, err = ensureIronicUpgradeJob(cctx, resources, preUpgrade)
 		if err != nil || !jobStatus.IsReady() {
 			return jobStatus, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

 Enable variable shadowing check in govet linter. Fix warnings caused by running the linter.

**Which issue(s) this PR fixes**:
Fixes #265 
