### PR TITLE
🌱 Enforce the JSON RPC port

### DIFF
--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -211,6 +211,12 @@ func buildIronicEnvVars(cctx ControllerContext, resources Resources) []corev1.En
 			Name:  "IRONIC_EXPOSE_JSON_RPC",
 			Value: strconv.FormatBool(resources.Ironic.Spec.HighAvailability),
 		},
+		// NOTE(dtantsur): this is necessary for the transition process from port 8089 (conflicting with kubernetes-nmstate)
+		// to port 6189 chosen for Metal3.
+		{
+			Name:  "OS_JSON_RPC__PORT",
+			Value: "8089",
+		},
 	}...)
 
 	if resources.Ironic.Spec.Database != nil {

--- a/pkg/ironic/containers_test.go
+++ b/pkg/ironic/containers_test.go
@@ -174,6 +174,8 @@ func TestExpectedExtraEnvVars(t *testing.T) {
 		"OS_PXE__BOOT_RETRY_TIMEOUT":            "1200",
 		"OS_CONDUCTOR__DEPLOY_CALLBACK_TIMEOUT": "4800",
 		"OS_CONDUCTOR__INSPECT_TIMEOUT":         "1800",
+		// This is currently set unconditionally by IrSO itself and will eventually be replaced by a proper ironic-image variable.
+		"OS_JSON_RPC__PORT": "8089",
 	}
 
 	ironic := &metal3api.Ironic{


### PR DESCRIPTION
This is necessary for the transition process to the new port number.

This is a backport of https://github.com/metal3-io/ironic-standalone-operator/commit/8287c0e1cd10525cb24f15d332440102335f370c