### PR TITLE
⚠️ Drop support for Ironic older than 30.0

### DIFF
--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -20,23 +20,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	majorVersion27 = 27
-	majorVersion28 = 28
-	majorVersion29 = 29
-	majorVersion30 = 30
-	majorVersion31 = 31
-	majorVersion32 = 32
-)
-
 var (
 	VersionLatest = Version{}
-	Version320    = Version{Major: majorVersion32, Minor: 0}
-	Version310    = Version{Major: majorVersion31, Minor: 0}
-	Version300    = Version{Major: majorVersion30, Minor: 0}
-	Version290    = Version{Major: majorVersion29, Minor: 0}
-	Version280    = Version{Major: majorVersion28, Minor: 0}
-	Version270    = Version{Major: majorVersion27, Minor: 0}
+	Version320    = Version{Major: 32, Minor: 0}
+	Version310    = Version{Major: 31, Minor: 0}
+	Version300    = Version{Major: 30, Minor: 0}
 )
 
 // SupportedVersions is a mapping of supported versions to container image tags.
@@ -48,9 +36,6 @@ var SupportedVersions = map[Version]string{
 	VersionLatest: "latest",
 	Version310:    "release-31.0",
 	Version300:    "release-30.0",
-	Version290:    "release-29.0",
-	Version280:    "release-28.0",
-	Version270:    "release-27.0",
 }
 
 // Inspection defines inspection settings.

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -158,7 +158,7 @@ func buildExtraConfigVars(ironic *metal3api.Ironic) []corev1.EnvVar {
 	return result
 }
 
-func databaseClientEnvVars(cctx ControllerContext, db *metal3api.Database) []corev1.EnvVar {
+func databaseClientEnvVars(db *metal3api.Database) []corev1.EnvVar {
 	envVars := []corev1.EnvVar{
 		{
 			Name:  "MARIADB_HOST",
@@ -170,37 +170,10 @@ func databaseClientEnvVars(cctx ControllerContext, db *metal3api.Database) []cor
 		},
 	}
 
-	// NOTE(dtantsur): remove when versions older than 29.0 are no longer supported
-	if cctx.VersionInfo.InstalledVersion.Compare(versionMountDatabaseSecret) < 0 {
-		envVars = append(envVars, []corev1.EnvVar{
-			{
-				Name: "MARIADB_USER",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: db.CredentialsName,
-						},
-						Key: "username",
-					},
-				},
-			},
-			{
-				Name: "MARIADB_PASSWORD",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: db.CredentialsName,
-						},
-						Key: "password",
-					},
-				},
-			}}...)
-	}
-
 	return envVars
 }
 
-func buildIronicEnvVars(cctx ControllerContext, resources Resources) []corev1.EnvVar {
+func buildIronicEnvVars(resources Resources) []corev1.EnvVar {
 	result := buildCommonEnvVars(resources.Ironic)
 	result = append(result, []corev1.EnvVar{
 		{
@@ -220,7 +193,7 @@ func buildIronicEnvVars(cctx ControllerContext, resources Resources) []corev1.En
 	}...)
 
 	if resources.Ironic.Spec.Database != nil {
-		result = append(result, databaseClientEnvVars(cctx, resources.Ironic.Spec.Database)...)
+		result = append(result, databaseClientEnvVars(resources.Ironic.Spec.Database)...)
 		// NOTE(dtantsur): upgrades are handled by a separate job
 		result = append(result, corev1.EnvVar{
 			Name:  "IRONIC_SKIP_DBSYNC",
@@ -294,22 +267,20 @@ func buildHttpdEnvVars(resources Resources) []corev1.EnvVar {
 	return result
 }
 
-func databaseClientMounts(cctx ControllerContext, db *metal3api.Database) (volumes []corev1.Volume, mounts []corev1.VolumeMount) {
-	if cctx.VersionInfo.InstalledVersion.Compare(versionMountDatabaseSecret) >= 0 {
-		volumes = append(volumes, corev1.Volume{
-			Name: "auth-mariadb",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName:  db.CredentialsName,
-					DefaultMode: ptr.To(corev1.SecretVolumeSourceDefaultMode),
-				},
+func databaseClientMounts(db *metal3api.Database) (volumes []corev1.Volume, mounts []corev1.VolumeMount) {
+	volumes = append(volumes, corev1.Volume{
+		Name: "auth-mariadb",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName:  db.CredentialsName,
+				DefaultMode: ptr.To(corev1.SecretVolumeSourceDefaultMode),
 			},
-		})
-		mounts = append(mounts, corev1.VolumeMount{
-			Name:      "auth-mariadb",
-			MountPath: authDir + "/mariadb",
-		})
-	}
+		},
+	})
+	mounts = append(mounts, corev1.VolumeMount{
+		Name:      "auth-mariadb",
+		MountPath: authDir + "/mariadb",
+	})
 
 	if db.TLSCertificateName != "" {
 		volumes = append(volumes, corev1.Volume{
@@ -330,7 +301,7 @@ func databaseClientMounts(cctx ControllerContext, db *metal3api.Database) (volum
 	return
 }
 
-func buildIronicVolumesAndMounts(cctx ControllerContext, resources Resources) (volumes []corev1.Volume, mounts []corev1.VolumeMount) {
+func buildIronicVolumesAndMounts(resources Resources) (volumes []corev1.Volume, mounts []corev1.VolumeMount) {
 	volumes = []corev1.Volume{
 		{
 			Name: "ironic-shared",
@@ -413,7 +384,7 @@ func buildIronicVolumesAndMounts(cctx ControllerContext, resources Resources) (v
 	}
 
 	if resources.Ironic.Spec.Database != nil {
-		dbVolumes, dbMounts := databaseClientMounts(cctx, resources.Ironic.Spec.Database)
+		dbVolumes, dbMounts := databaseClientMounts(resources.Ironic.Spec.Database)
 		volumes = append(volumes, dbVolumes...)
 		mounts = append(mounts, dbMounts...)
 	}
@@ -589,7 +560,7 @@ func newIronicPodTemplate(cctx ControllerContext, resources Resources) (corev1.P
 	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
 		"IPA_BASEURI", os.Getenv("IPA_BASEURI"))
 
-	volumes, mounts := buildIronicVolumesAndMounts(cctx, resources)
+	volumes, mounts := buildIronicVolumesAndMounts(resources)
 	sharedVolumeMount := mounts[0]
 
 	var initContainers []corev1.Container
@@ -620,7 +591,7 @@ func newIronicPodTemplate(cctx ControllerContext, resources Resources) (corev1.P
 			Name:         "ironic",
 			Image:        cctx.VersionInfo.IronicImage,
 			Command:      []string{"/bin/runironic"},
-			Env:          buildIronicEnvVars(cctx, resources),
+			Env:          buildIronicEnvVars(resources),
 			VolumeMounts: mounts,
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser:  ptr.To(ironicUser),

--- a/pkg/ironic/ironic.go
+++ b/pkg/ironic/ironic.go
@@ -162,12 +162,6 @@ func EnsureIronic(cctx ControllerContext, resources Resources) (status Status, e
 		return
 	}
 
-	if resources.Ironic.Spec.HighAvailability && cctx.VersionInfo.InstalledVersion.Compare(versionWithoutAuthConfig) < 0 {
-		err = errors.New("using HA is only possible for Ironic 28.0 or newer")
-		status = Status{Fatal: err}
-		return
-	}
-
 	if resources.Ironic.Spec.Database != nil {
 		var jobStatus Status
 		jobStatus, err = ensureIronicUpgradeJob(cctx, resources, preUpgrade)

--- a/pkg/ironic/utils.go
+++ b/pkg/ironic/utils.go
@@ -261,15 +261,7 @@ func appendListOfStringsEnv(envVars []corev1.EnvVar, name string, value []string
 	return envVars
 }
 
-func hasReadOnlyRootFilesystem(cctx ControllerContext) bool {
-	return cctx.VersionInfo.InstalledVersion.Compare(versionDataMounts) >= 0
-}
-
-func addDataVolumes(cctx ControllerContext, podTemplate corev1.PodTemplateSpec) corev1.PodTemplateSpec {
-	if !hasReadOnlyRootFilesystem(cctx) {
-		return podTemplate
-	}
-
+func addDataVolumes(podTemplate corev1.PodTemplateSpec) corev1.PodTemplateSpec {
 	podTemplate.Spec.Volumes = append(podTemplate.Spec.Volumes, corev1.Volume{
 		Name: dataVolumeName,
 		VolumeSource: corev1.VolumeSource{

--- a/pkg/ironic/validation_test.go
+++ b/pkg/ironic/validation_test.go
@@ -201,7 +201,7 @@ func TestValidateIronic(t *testing.T) {
 		{
 			Scenario: "with version",
 			Ironic: metal3api.IronicSpec{
-				Version: "27.0",
+				Version: "31.0",
 			},
 		},
 		{
@@ -216,7 +216,7 @@ func TestValidateIronic(t *testing.T) {
 			Ironic: metal3api.IronicSpec{
 				Version: "42.42",
 			},
-			ExpectedError: "version 42.42 is not supported, supported versions are 27.0, 28.0, 29.0, 30.0, 31.0, latest",
+			ExpectedError: "version 42.42 is not supported, supported versions are 30.0, 31.0, latest",
 		},
 		{
 			Scenario: "change existing database config",

--- a/pkg/ironic/version.go
+++ b/pkg/ironic/version.go
@@ -17,11 +17,7 @@ var (
 	defaultRamdiskDownloaderImage = defaultRegistry + "/ironic-ipa-downloader:latest"
 	defaultKeepalivedImage        = defaultRegistry + "/keepalived:latest"
 
-	versionWithoutAuthConfig   = metal3api.Version280
-	versionUpgradeScripts      = metal3api.Version290
-	versionMountDatabaseSecret = metal3api.Version290
-	versionDataMounts          = metal3api.Version290
-	versionBMCCA               = metal3api.Version320
+	versionBMCCA = metal3api.Version320
 )
 
 type VersionInfo struct {

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -62,9 +62,6 @@ import (
 const (
 	// NOTE(dtantsur): latest is now at least 1.99, so we can rely on this
 	// value to check that specifying Version: 31.0 actually installs 31.0.
-	apiVersionIn270 = "1.94"
-	apiVersionIn280 = "1.95"
-	apiVersionIn290 = "1.96"
 	apiVersionIn300 = "1.99"
 	apiVersionIn310 = "1.99"
 	// Update this periodically to make sure we're installing the latest version by default.
@@ -915,18 +912,6 @@ var _ = Describe("Ironic object tests", func() {
 		VerifyIronic(ironic, TestAssumptions{withTLS: true})
 	})
 
-	It("creates Ironic 27.0 and upgrades to 28.0", Label("v270-to-280", "upgrade"), func() {
-		testUpgrade("27.0", "28.0", apiVersionIn270, apiVersionIn280, namespace)
-	})
-
-	It("creates Ironic 28.0 and upgrades to 29.0", Label("v280-to-290", "upgrade"), func() {
-		testUpgrade("28.0", "29.0", apiVersionIn280, apiVersionIn290, namespace)
-	})
-
-	It("creates Ironic 29.0 and upgrades to 30.0", Label("v290-to-300", "upgrade"), func() {
-		testUpgrade("29.0", "30.0", apiVersionIn290, apiVersionIn300, namespace)
-	})
-
 	It("creates Ironic 30.0 and upgrades to 31.0", Label("v300-to-310", "upgrade"), func() {
 		testUpgrade("30.0", "31.0", apiVersionIn300, apiVersionIn310, namespace)
 	})
@@ -945,7 +930,7 @@ var _ = Describe("Ironic object tests", func() {
 
 		ironic := helpers.NewIronic(ctx, k8sClient, name, metal3api.IronicSpec{
 			Database: helpers.CreateDatabase(ctx, k8sClient, name),
-			Version:  "28.0",
+			Version:  "31.0",
 		})
 		DeferCleanup(func() {
 			CollectLogs(namespace)
@@ -953,24 +938,16 @@ var _ = Describe("Ironic object tests", func() {
 		})
 
 		ironic = WaitForIronic(name)
-		VerifyIronic(ironic, TestAssumptions{maxAPIVersion: apiVersionIn280})
+		VerifyIronic(ironic, TestAssumptions{maxAPIVersion: apiVersionIn310})
 
-		By("downgrading to Ironic 27.0")
+		By("downgrading to Ironic 30.0")
 
 		patch := client.MergeFrom(ironic.DeepCopy())
-		ironic.Spec.Version = "27.0"
+		ironic.Spec.Version = "30.0"
 		err := k8sClient.Patch(ctx, ironic, patch)
 		Expect(err).NotTo(HaveOccurred())
 
 		WaitForIronicFailure(name, "Ironic does not support downgrades", true)
-	})
-
-	It("creates Ironic 28.0 with HA and upgrades to 29.0", Label("ha-v280-to-v290", "ha", "upgrade"), func() {
-		testUpgradeHA("28.0", "29.0", apiVersionIn280, apiVersionIn290, namespace)
-	})
-
-	It("creates Ironic 29.0 with HA and upgrades to 30.0", Label("ha-v290-to-300", "ha", "upgrade"), func() {
-		testUpgradeHA("29.0", "30.0", apiVersionIn290, apiVersionIn300, namespace)
 	})
 
 	It("creates Ironic 30.0 with HA and upgrades to 31.0", Label("ha-v300-to-310", "ha", "upgrade"), func() {


### PR DESCRIPTION
27.0 and 28.0 are EOL per Ironic policy. 29.0 reaches 6 months tomorrow.
It will be supported for a while because it's a part of the coordinated
release, but from our perspective it's time to drop it as well.
Removing 29.0 in particular allows simplifying a lot of currently
version-dependent logic.

With the upcoming 32.0, IrSO 0.6 will support 3 Ironic versions.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
