### PR TITLE
🌱 cmd: strip out symbol table & DWARF debugging info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a26616
 FROM $BUILD_IMAGE AS builder
 
 WORKDIR /workspace
+ARG LDFLAGS=-s -w -extldflags=-static
 # Copy the Go Modules manifests
 COPY go.mod go.sum ./
 COPY api/go.mod api/go.sum api/
@@ -20,7 +21,8 @@ COPY internal/ internal/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 go build -a -ldflags "${LDFLAGS}" \
+    -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 FROM $BASE_IMAGE

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
+.PHONY: docker-build-debug
+docker-build-debug: test ## Build docker image with the manager with debug info.
+	docker build --build-arg LDFLAGS="-extldflags=-static" -t ${IMG} .
+
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}


### PR DESCRIPTION
**What this PR does / why we need it**:
DWARF is mostly needed when we are using Delve. DWARF was originally created for C language and the need for it in go and other debugging features is very small in general. As such, switch to using `-ldflags="-s -w"` by default and have an option to opt in for debugging info for those who would really need it. As a real example, we can gain ~30% (i.e. 27MB) image size reduction for the operator and faster build process.

Image & binary size profiler comparison **after** the change:
```
docker images --format "{{.Repository}} {{.Size}}" | grep ironic
quay.io/metal3-io/ironic-standalone-operator 63.1MB

```
```
bloaty -d sections manager
    FILE SIZE        VM SIZE
 --------------  --------------
  46.4%  26.9Mi  46.2%  26.9Mi    .text
  33.7%  19.5Mi  33.6%  19.5Mi    .gopclntab
  18.3%  10.6Mi  18.2%  10.6Mi    .rodata
   1.0%   565Ki   1.0%   565Ki    .noptrdata
   0.4%   233Ki   0.4%   233Ki    .data
   0.0%       0   0.4%   218Ki    .bss
   0.2%  94.9Ki   0.2%  94.9Ki    .typelink
   0.0%       0   0.1%  61.0Ki    .noptrbss
   0.1%  34.7Ki   0.1%  34.7Ki    .itablink
   0.0%  7.73Ki   0.0%  7.73Ki    .go.buildinfo
   0.0%  4.42Ki   0.0%       0    [Unmapped]
   0.0%  3.12Ki   0.0%  3.12Ki    [LOAD #2 [RX]]
   0.0%     248   0.0%      64    .shstrtab
   0.0%     184   0.0%     184    .go.fipsinfo
   0.0%     164   0.0%     164    .note.go.buildid
   0.0%     100   0.0%     100    .note.gnu.build-id
   0.0%      69   0.0%      85    [LOAD #4 [RW]]
   0.0%      55   0.0%      55    [LOAD #3 [R]]
 100.0%  57.9Mi 100.0%  58.2Mi    TOTAL

```
**before** the change
```
docker images --format "{{.Repository}} {{.Size}}" | grep ironic
quay.io/metal3-io/ironic-standalone-operator 90.8MB

```
```
bloaty -d sections manager
    FILE SIZE        VM SIZE
 --------------  --------------
  31.9%  26.9Mi  46.2%  26.9Mi    .text
  23.2%  19.5Mi  33.6%  19.5Mi    .gopclntab
  12.5%  10.6Mi  18.2%  10.6Mi    .rodata
   8.4%  7.09Mi   0.0%      64    .strtab
   7.8%  6.56Mi   0.0%      64    .debug_info
   5.5%  4.60Mi   0.0%      64    .debug_loc
   4.0%  3.40Mi   0.0%      64    .debug_line
   2.9%  2.42Mi   0.0%      64    .symtab
   1.6%  1.38Mi   0.0%      64    .debug_ranges
   1.1%   910Ki   0.0%      64    .debug_frame
   0.7%   565Ki   1.0%   565Ki    .noptrdata
   0.3%   233Ki   0.4%   233Ki    .data
   0.0%       0   0.4%   218Ki    .bss
   0.1%  94.9Ki   0.2%  94.9Ki    .typelink
   0.0%       0   0.1%  61.0Ki    .noptrbss
   0.0%  34.7Ki   0.1%  34.7Ki    .itablink
   0.0%  7.69Ki   0.0%  7.69Ki    .go.buildinfo
   0.0%  4.52Ki   0.0%       0    [Unmapped]
   0.0%  2.55Ki   0.0%  2.55Ki    [LOAD #2 [RX]]
   0.0%    1021   0.0%     700    [7 Others]
   0.0%     407   0.0%      64    .debug_abbrev
 100.0%  84.2Mi 100.0%  58.2Mi    TOTAL
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
