### PR TITLE
:seedling: Add release target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,19 @@ RELEASE_NOTES_DIR := releasenotes
 $(RELEASE_NOTES_DIR):
 	mkdir -p $(RELEASE_NOTES_DIR)/
 
+.PHONY: release-manifests
+release-manifests: $(KUSTOMIZE) $(RELEASE_DIR) ## Builds the manifests to publish with a release
+	$(KUSTOMIZE) build config/default > $(RELEASE_DIR)/install.yaml
+
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
 	cd hack/tools && $(GO) run release/notes.go  --releaseTag=$(RELEASE_TAG) > $(realpath $(RELEASE_NOTES_DIR))/$(RELEASE_TAG).md
+
+.PHONY: release
+release: kustomize
+	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
+	@if ! [ -z "$$(git status --porcelain)" ]; then echo "You have uncommitted changes"; exit 1; fi
+	git checkout "${RELEASE_TAG}"
+	cd config/manager && $(KUSTOMIZE) edit set image quay.io/metal3-io/ironic-standalone-operator="$(IMG_NO_TAG):${RELEASE_TAG}"
+	$(MAKE) release-manifests
+	$(MAKE) release-notes


### PR DESCRIPTION
So when we create the release notes nothing explodes

Signed-off-by: Riccardo Pittau <elfosardo@gmail.com>
