### PR TITLE
🌱Uplift go 1.24.8 to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.24.6@sha256:2c89c41fb9efc3807029b59af69645867cfe978d2b877d475be0d72f6c6ce6f6
+ARG BUILD_IMAGE=docker.io/golang:1.24.8@sha256:dd80b4158d9c4ca750687719d1a4b79ec9f78f19c4b87b53b73d552ceccfb7a8
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL = /usr/bin/env bash -o pipefail
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.24.6
+GO_VERSION ?= 1.24.8
 GO := $(shell type -P go)
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell $(GO) env GOPROXY)


### PR DESCRIPTION
Uplift go 1.24.8 to address the security vulnerabilities. These minor releases include PRIVATE security fixes to the standard library, covering the following CVEs: [announcement](https://groups.google.com/g/golang-announce/c/ask65OnfzGU)
CVE-2025-61724
CVE-2025-61725
CVE-2025-58187
CVE-2025-61723
CVE-2025-47912
CVE-2025-58185
CVE-2025-58186
CVE-2025-58188
CVE-2025-58183