### PR TITLE
🌱 Make IrSO configmap name predictable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ bin/
 # IDE files
 .idea
 .vscode/
+.devcontainer/
 
 # Release artifacts
 out/

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,6 +4,10 @@ kind: Kustomization
 resources:
 - manager.yaml
 
+# Make the name of this configmap predictable so users can reference it.
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
 - envs:
   - manager.env


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes it easier for users to make use of the configmap. As it is now, if we decide to add something default to it, the hash changes and users would need to check the name on each new release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
