### PR TITLE
🌱 Do not mount service account token on Ironic pods

### DIFF
--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -667,9 +667,10 @@ func newIronicPodTemplate(cctx ControllerContext, resources Resources) (corev1.P
 			InitContainers: initContainers,
 			Volumes:        volumes,
 			// Ironic needs to be accessed by external machines
-			HostNetwork:  true,
-			DNSPolicy:    corev1.DNSClusterFirstWithHostNet,
-			NodeSelector: resources.Ironic.Spec.NodeSelector,
+			HostNetwork:                  true,
+			DNSPolicy:                    corev1.DNSClusterFirstWithHostNet,
+			NodeSelector:                 resources.Ironic.Spec.NodeSelector,
+			AutomountServiceAccountToken: ptr.To(false),
 		},
 	}), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Ironic has no need to authenticate or communicate with the Kubernetes API, so there is no reason to mount the service account token. This commit explicitly configures Kubernetes to not mount it. By default, each pod will always mount the default service account if nothing is specified.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
