### PR TITLE
✨ Add support for custom CA certificates

### DIFF
--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -192,6 +192,14 @@ type TLS struct {
 	// +optional
 	CertificateName string `json:"certificateName,omitempty"`
 
+	// TrustedCAName is a reference to the configmap with the CA certificate(s)
+	// to use when validating TLS connections to image servers and other services.
+	// The configmap should contain one or more CA certificates in PEM format.
+	// If the configmap contains multiple keys, only the first key will be used and
+	// a warning will be logged.
+	// +optional
+	TrustedCAName string `json:"trustedCAName,omitempty"`
+
 	// DisableVirtualMediaTLS turns off TLS on the virtual media server,
 	// which may be required for hardware that cannot accept HTTPS links.
 	// +optional

--- a/config/crd/bases/ironic.metal3.io_ironics.yaml
+++ b/config/crd/bases/ironic.metal3.io_ironics.yaml
@@ -3226,6 +3226,14 @@ spec:
                       Has no effect when HighAvailability is false and requires the
                       HighAvailability feature gate to be set.
                     type: boolean
+                  trustedCAName:
+                    description: |-
+                      TrustedCAName is a reference to the configmap with the CA certificate(s)
+                      to use when validating TLS connections to image servers and other services.
+                      The configmap should contain one or more CA certificates in PEM format.
+                      If the configmap contains multiple keys, only the first key will be used and
+                      a warning will be logged.
+                    type: string
                 type: object
               version:
                 description: |-

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - pods
   verbs:
   - get

--- a/docs/api.md
+++ b/docs/api.md
@@ -6523,6 +6523,17 @@ Has no effect when HighAvailability is false and requires the
 HighAvailability feature gate to be set.<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>trustedCAName</b></td>
+        <td>string</td>
+        <td>
+          TrustedCAName is a reference to the configmap with the CA certificate(s)
+to use when validating TLS connections to image servers and other services.
+The configmap should contain one or more CA certificates in PEM format.
+If the configmap contains multiple keys, only the first key will be used and
+a warning will be logged.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/pkg/ironic/utils.go
+++ b/pkg/ironic/utils.go
@@ -42,10 +42,11 @@ type ControllerContext struct {
 }
 
 type Resources struct {
-	Ironic      *metal3api.Ironic
-	APISecret   *corev1.Secret
-	TLSSecret   *corev1.Secret
-	BMCCASecret *corev1.Secret
+	Ironic             *metal3api.Ironic
+	APISecret          *corev1.Secret
+	TLSSecret          *corev1.Secret
+	BMCCASecret        *corev1.Secret
+	TrustedCAConfigMap *corev1.ConfigMap
 }
 
 func mergeContainers(target, source []corev1.Container) []corev1.Container {


### PR DESCRIPTION
Adds a new TLS.TrustedCAName field that allows users to provide a ConfigMap containing CA certificates for validating HTTPS connections to image servers and other services. This enables Ironic to access images hosted behind self-signed or custom CA certificates.

The implementation uses Ironic's native WEBSERVER_CACERT_FILE environment variable which configures the webserver_verify_ca option in ironic.conf. This approach is superior to using generic Python environment variables (REQUESTS_CA_BUNDLE, SSL_CERT_FILE) which would override the entire Python requests library trust store globally and could interfere with BMC CA validation and other TLS operations.

The ConfigMap is mounted at /certs/ca/trusted (following existing ironic-image conventions) rather than OS-specific paths like /etc/pki/ca-trust/extracted/pem, making the implementation OS-agnostic. The operator automatically uses the first key found in the ConfigMap, logging warnings for any additional keys that are ignored. This provides flexibility for users while maintaining simplicity.

The operator does not manage or claim ownership of the user-provided ConfigMap, it simply references it for mounting into the Ironic pods.