### PR TITLE
:seedling: add missing markdownlint config file and fix issues

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,9 @@
+# Reference: https://github.com/DavidAnson/markdownlint-cli2#markdownlint-cli2yaml
+
+config:
+  ul-indent:
+    # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
+    indent: 3
+
+# Don't autofix anything, we're linting here
+fix: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ GitHub pull requests.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Certificate of Origin](#certificate-of-origin)
-  - [Git commit Sign-off](#git-commit-sign-off)
+   - [Git commit Sign-off](#git-commit-sign-off)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,7 +16,7 @@ Things you should check before making a release:
 - Use the `./hack/verify-release.sh` script as helper to identify possible
   issues to be addressed before creating any release tags. It verifies issues
   like:
-  - Verify any other direct or indirect dependency is uplifted to close any public
+   - Verify any other direct or indirect dependency is uplifted to close any public
     vulnerabilities
 
 To make sure the correct Ironic versions are supported and tested:
@@ -24,10 +24,10 @@ To make sure the correct Ironic versions are supported and tested:
 - Add any missing versions and their branch names to the [list of versions
   in the API][supported-versions].
 - Extend the [functional tests suite][suite_test] with new tests if needed:
-  - update [the list of known Ironic API versions][known-api-versions] using
+   - update [the list of known Ironic API versions][known-api-versions] using
     the [Ironic API versions listing][api-versions-list].
-  - upgrade from the newest version to `latest` with and without HA
-  - upgrade to the newest version from the one before it (with and without HA)
+   - upgrade from the newest version to `latest` with and without HA
+   - upgrade to the newest version from the one before it (with and without HA)
   Hint: you can usually copy existing tests, modifying only the `spec.version`
   field and the API versions on the `TestAssumptions` structure.
 
@@ -93,12 +93,12 @@ Create a development branch (e.g. `prepare-0.x`) from the newly created branch:
   [Prior art](https://github.com/metal3-io/ironic-standalone-operator/pull/388).
 
 - Commit your changes, push the new branch and create a pull request:
-  - The commit and PR title should be
+   - The commit and PR title should be
     ✨ Switch to Ironic X.Y by default, prepare release-0.x:
     -`git commit -S -s -m ":sparkles: Switch to Ironic X.Y by default, prepare release-0.x"`
      where X.Y is the Ironic branch you used [above][default-version]
     -`git push -u origin prepare-0.x`
-  - The pull request must target the new branch (`release-0.x`), not `main`!
+   - The pull request must target the new branch (`release-0.x`), not `main`!
 
 Wait for the pull request to be merged before proceeding.
 
@@ -114,25 +114,25 @@ Wait for the pull request to be merged before proceeding.
   `git checkout -b release-notes-0.x.x origin/main`
 
 - Generate the release notes: `RELEASE_TAG=v0.x.x make release-notes`
-  - Replace `v0.x.x` with the new release tag you're creating.
-  - This command generates the release notes here
+   - Replace `v0.x.x` with the new release tag you're creating.
+   - This command generates the release notes here
     `releasenotes/<RELEASE_TAG>.md` .
 
 - Next step is to clean up the release note manually.
-  - If release is not a beta or release candidate, check for duplicates,
+   - If release is not a beta or release candidate, check for duplicates,
     reverts, and incorrect classifications of PRs, and whatever release
     creation tagged to be manually checked.
-  - For any superseded PRs (like same dependency uplifted multiple times, or
+   - For any superseded PRs (like same dependency uplifted multiple times, or
     commit revertion) that provide no value to the release, move them to
     Superseded section. This way the changes are acknowledged to be part of the
     release, but not overwhelming the important changes contained by the
     release.
 
 - Commit your changes, push the new branch and create a pull request:
-  - The commit and PR title should be 🚀 Release v0.x.y:
+   - The commit and PR title should be 🚀 Release v0.x.y:
      -`git commit -S -s -m ":rocket: Release v0.x.x"`
      -`git push -u origin release-notes-0.x.x`
-  - Important! The commit should only contain the release notes file, nothing
+   - Important! The commit should only contain the release notes file, nothing
     else, otherwise automation will not work.
 
 - Ask maintainers and release team members to review your pull request.
@@ -140,10 +140,10 @@ Wait for the pull request to be merged before proceeding.
 Once PR is merged following GitHub actions are triggered:
 
 - GitHub action `Create Release` runs following jobs:
-  - GitHub job `push_release_tags` will create and push the tags. This action
+   - GitHub job `push_release_tags` will create and push the tags. This action
     will also create release branch if its missing and release is `rc` or
     minor.
-  - GitHub job `create draft release` creates draft release. Don't publish the
+   - GitHub job `create draft release` creates draft release. Don't publish the
     release until release tag is visible in. Running actions are visible on the
     [Actions](https://github.com/metal3-io/ironic-standalone-operator/actions)
     page, and draft release will be visible on top of the
@@ -152,10 +152,10 @@ Once PR is merged following GitHub actions are triggered:
     or a new patch release from the latest release branch, uncheck the box for
     latest release. If it is a release candidate (RC) or a beta release,
     tick pre-release box.
-  - GitHub job `build_irso` build release images with the
+   - GitHub job `build_irso` build release images with the
     release tag, and push them to Quay. Make sure the release tags are visible in
     Quay tags pages:
-    - [IrSO](https://quay.io/repository/metal3-io/ironic-standalone-operator?tab=tags)
+      - [IrSO](https://quay.io/repository/metal3-io/ironic-standalone-operator?tab=tags)
     If the new release tag is not available for any of the images, check if the
     action has failed and retrigger as necessary.
 


### PR DESCRIPTION
For whatever reason, we have forgotten to bring in the markdownlint config file. This has led to some files having now linting failures, which are also fixed in this PR.
