### PR TITLE
:sparkles: use SecretManager to handle access to cluster secrets

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/metal3-io/ironic-standalone-operator/internal/controller"
 	webhookv1alpha1 "github.com/metal3-io/ironic-standalone-operator/internal/webhook/v1alpha1"
 	"github.com/metal3-io/ironic-standalone-operator/pkg/ironic"
+	"github.com/metal3-io/ironic-standalone-operator/pkg/secretutils"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -191,6 +192,7 @@ func main() {
 		LeaderElectionNamespace: watchNamespace,
 		Cache: cache.Options{
 			DefaultNamespaces: watchNamespaces,
+			ByObject:          secretutils.AddSecretSelector(nil),
 		},
 	}
 
@@ -203,6 +205,7 @@ func main() {
 	if err = (&controller.IronicReconciler{
 		Client:      mgr.GetClient(),
 		KubeClient:  kubeClient,
+		APIReader:   mgr.GetAPIReader(),
 		Scheme:      mgr.GetScheme(),
 		Log:         ctrl.Log.WithName("controllers").WithName("Ironic"),
 		Domain:      clusterDomain,

--- a/pkg/secretutils/label.go
+++ b/pkg/secretutils/label.go
@@ -1,0 +1,35 @@
+package secretutils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	LabelEnvironmentName  = "environment.metal3.io/ironic-standalone-operator"
+	LabelEnvironmentValue = "true"
+)
+
+// AddSecretSelector adds a selector to a cache.ByObject map that filters
+// Secrets so that only those labelled as part of the ironic environment get
+// cached. The input may be nil.
+func AddSecretSelector(selectors map[client.Object]cache.ByObject) map[client.Object]cache.ByObject {
+	secret := &corev1.Secret{}
+	newSelectors := map[client.Object]cache.ByObject{
+		secret: {
+			Label: labels.SelectorFromSet(
+				labels.Set{
+					LabelEnvironmentName: LabelEnvironmentValue,
+				}),
+		},
+	}
+
+	if selectors == nil {
+		return newSelectors
+	}
+
+	selectors[secret] = newSelectors[secret]
+	return selectors
+}

--- a/pkg/secretutils/label_test.go
+++ b/pkg/secretutils/label_test.go
@@ -1,0 +1,23 @@
+package secretutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestAddSecretSelector_NilInput(t *testing.T) {
+	result := AddSecretSelector(nil)
+	assert.Len(t, result, 1)
+}
+
+func TestAddSecretSelector_ExistingMap(t *testing.T) {
+	existing := make(map[client.Object]cache.ByObject)
+	result := AddSecretSelector(existing)
+
+	assert.Len(t, result, 1)
+	// Verify it returns the same map reference (modified in place)
+	assert.Equal(t, &existing, &result)
+}

--- a/pkg/secretutils/secret_manager.go
+++ b/pkg/secretutils/secret_manager.go
@@ -1,0 +1,122 @@
+package secretutils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// SecretManager is a type for fetching Secrets whether or not they are in the
+// client cache, labelling so that they will be included in the client cache,
+// and optionally setting an owner reference.
+type SecretManager struct {
+	ctx       context.Context
+	log       logr.Logger
+	client    client.Client
+	apiReader client.Reader
+}
+
+// NewSecretManager returns a new SecretManager.
+func NewSecretManager(ctx context.Context, log logr.Logger, cacheClient client.Client, apiReader client.Reader) SecretManager {
+	return SecretManager{
+		ctx:       ctx,
+		log:       log.WithName("secret_manager"),
+		client:    cacheClient,
+		apiReader: apiReader,
+	}
+}
+
+// findSecret retrieves a Secret from the cache if it is available, and from the
+// k8s API if not.
+func (sm *SecretManager) findSecret(key types.NamespacedName) (secret *corev1.Secret, err error) {
+	secret = &corev1.Secret{}
+
+	// Look for secret in the filtered cache
+	err = sm.client.Get(sm.ctx, key, secret)
+	if err == nil {
+		return secret, nil
+	}
+	if !k8serrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	// Secret not in cache; check API directly for unlabelled Secret
+	err = sm.apiReader.Get(sm.ctx, key, secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}
+
+// claimSecret ensures that the Secret has a label that will ensure it is
+// present in the cache (and that we can watch for changes), and optionally
+// that it has a particular owner reference.
+func (sm *SecretManager) claimSecret(secret *corev1.Secret, owner client.Object, scheme *runtime.Scheme) error {
+	log := sm.log.WithValues("secret", secret.Name, "secretNamespace", secret.Namespace)
+	needsUpdate := false
+
+	if !metav1.HasLabel(secret.ObjectMeta, LabelEnvironmentName) {
+		log.Info("setting secret environment label")
+		metav1.SetMetaDataLabel(&secret.ObjectMeta, LabelEnvironmentName, LabelEnvironmentValue)
+		needsUpdate = true
+	}
+
+	if owner != nil && scheme != nil {
+		ownerLog := log.WithValues(
+			"ownerKind", owner.GetObjectKind().GroupVersionKind().Kind,
+			"owner", owner.GetNamespace()+"/"+owner.GetName(),
+			"ownerUID", owner.GetUID())
+
+		alreadyOwned := false
+		ownerUID := owner.GetUID()
+		for _, ref := range secret.GetOwnerReferences() {
+			if ref.UID == ownerUID {
+				alreadyOwned = true
+				break
+			}
+		}
+		if !alreadyOwned {
+			ownerLog.Info("setting secret owner reference")
+			if err := controllerutil.SetOwnerReference(owner, secret, scheme); err != nil {
+				return fmt.Errorf("failed to set secret owner reference: %w", err)
+			}
+			needsUpdate = true
+		}
+	}
+
+	if needsUpdate {
+		if err := sm.client.Update(sm.ctx, secret); err != nil {
+			return fmt.Errorf("failed to update secret %s in namespace %s: %w", secret.Name, secret.Namespace, err)
+		}
+	}
+
+	return nil
+}
+
+// AcquireSecret retrieves a Secret and ensures that it has a label that will
+// ensure it is present in the cache (and that we can watch for changes), and
+// that it has a particular owner reference.
+func (sm *SecretManager) AcquireSecret(key types.NamespacedName, owner client.Object, scheme *runtime.Scheme) (*corev1.Secret, error) {
+	secret, err := sm.findSecret(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch secret %s in namespace %s: %w", key.Name, key.Namespace, err)
+	}
+	err = sm.claimSecret(secret, owner, scheme)
+	return secret, err
+}
+
+// ObtainSecret retrieves a Secret and ensures that it has a label that will
+// ensure it is present in the cache (and that we can watch for changes).
+// This version does not set owner references.
+func (sm *SecretManager) ObtainSecret(key types.NamespacedName) (*corev1.Secret, error) {
+	return sm.AcquireSecret(key, nil, nil)
+}

--- a/pkg/secretutils/secret_manager_test.go
+++ b/pkg/secretutils/secret_manager_test.go
@@ -1,0 +1,394 @@
+package secretutils
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
+)
+
+func newTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = metal3api.AddToScheme(scheme)
+	return scheme
+}
+
+func TestSecretManager_ObtainSecret_NotFound(t *testing.T) {
+	scheme := newTestScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	_, err := sm.ObtainSecret(types.NamespacedName{Name: "nonexistent", Namespace: "test"})
+	require.Error(t, err)
+}
+
+func TestSecretManager_ObtainSecret_FoundInCache(t *testing.T) {
+	scheme := newTestScheme()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test",
+			Labels: map[string]string{
+				LabelEnvironmentName: LabelEnvironmentValue,
+			},
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("secret"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	result, err := sm.ObtainSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"})
+	require.NoError(t, err)
+	assert.Equal(t, "test-secret", result.Name)
+	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+}
+
+func TestSecretManager_ObtainSecret_AddsLabel(t *testing.T) {
+	scheme := newTestScheme()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("secret"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	result, err := sm.ObtainSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"})
+	require.NoError(t, err)
+	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+
+	// Verify the label was persisted
+	var updated corev1.Secret
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "test-secret", Namespace: "test"}, &updated)
+	require.NoError(t, err)
+	assert.Equal(t, LabelEnvironmentValue, updated.Labels[LabelEnvironmentName])
+}
+
+func TestSecretManager_AcquireSecret_WithOwner(t *testing.T) {
+	scheme := newTestScheme()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("secret"),
+		},
+	}
+
+	owner := &metal3api.Ironic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ironic",
+			Namespace: "test",
+			UID:       "test-uid-12345",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, owner).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	result, err := sm.AcquireSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"}, owner, scheme)
+	require.NoError(t, err)
+	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+
+	// Verify owner reference was added
+	var updated corev1.Secret
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "test-secret", Namespace: "test"}, &updated)
+	require.NoError(t, err)
+	assert.Len(t, updated.OwnerReferences, 1)
+	assert.Equal(t, owner.UID, updated.OwnerReferences[0].UID)
+}
+
+func TestSecretManager_AcquireSecret_AlreadyLabeled(t *testing.T) {
+	scheme := newTestScheme()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test",
+			Labels: map[string]string{
+				LabelEnvironmentName: LabelEnvironmentValue,
+			},
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	result, err := sm.ObtainSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"})
+	require.NoError(t, err)
+	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+}
+
+func TestSecretManager_AcquireSecret_AlreadyOwned(t *testing.T) {
+	scheme := newTestScheme()
+
+	owner := &metal3api.Ironic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ironic",
+			Namespace: "test",
+			UID:       "test-uid-12345",
+		},
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test",
+			Labels: map[string]string{
+				LabelEnvironmentName: LabelEnvironmentValue,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "ironic.metal3.io/v1alpha1",
+					Kind:       "Ironic",
+					Name:       owner.Name,
+					UID:        owner.UID,
+				},
+			},
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, owner).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	result, err := sm.AcquireSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"}, owner, scheme)
+	require.NoError(t, err)
+	assert.Equal(t, "test-secret", result.Name)
+
+	// Should still have exactly one owner reference
+	var updated corev1.Secret
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "test-secret", Namespace: "test"}, &updated)
+	require.NoError(t, err)
+	assert.Len(t, updated.OwnerReferences, 1)
+}
+
+func TestSecretManager_FallbackToAPIReader(t *testing.T) {
+	scheme := newTestScheme()
+
+	// Secret exists only in the "API" (apiReader), not in the cache
+	// This simulates an unlabeled secret that's not in the filtered cache
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "uncached-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"data": []byte("value"),
+		},
+	}
+
+	// Both clients have the secret (in real scenario, cache would filter it out,
+	// but for testing we simulate the fallback by using separate clients)
+	// The key behavior we're testing is that findSecret tries cache first, then API
+	cacheClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), cacheClient, apiReader)
+
+	// The secret should be found (via cache in this test, but the fallback logic is tested)
+	result, err := sm.ObtainSecret(types.NamespacedName{Name: "uncached-secret", Namespace: "test"})
+	require.NoError(t, err)
+	assert.Equal(t, "uncached-secret", result.Name)
+	// Label should be added
+	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+}
+
+func TestSecretManager_NotInCacheButInAPI(t *testing.T) {
+	scheme := newTestScheme()
+
+	// Secret exists only in the API reader, not in the cache client
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api-only-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"data": []byte("value"),
+		},
+	}
+
+	// Empty cache client, secret only in API reader
+	cacheClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), cacheClient, apiReader)
+
+	// findSecret should find it via API fallback, but claimSecret will fail
+	// because the secret doesn't exist in the cache client for update
+	// This tests the fallback path in findSecret
+	_, err := sm.ObtainSecret(types.NamespacedName{Name: "api-only-secret", Namespace: "test"})
+	// We expect an error because we can't update a secret that doesn't exist in the cache client
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestSecretManager_AcquireSecret_WithOwnerNoScheme(t *testing.T) {
+	scheme := newTestScheme()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+		},
+	}
+
+	owner := &metal3api.Ironic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ironic",
+			Namespace: "test",
+			UID:       "test-uid-12345",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, owner).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	// When scheme is nil, owner reference should not be set (only label)
+	result, err := sm.AcquireSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"}, owner, nil)
+	require.NoError(t, err)
+	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+
+	// Verify NO owner reference was added (scheme was nil)
+	var updated corev1.Secret
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "test-secret", Namespace: "test"}, &updated)
+	require.NoError(t, err)
+	assert.Empty(t, updated.OwnerReferences)
+}
+
+func TestSecretManager_AcquireSecret_NilOwnerWithScheme(t *testing.T) {
+	scheme := newTestScheme()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	// When owner is nil, only label should be set (same as ObtainSecret)
+	result, err := sm.AcquireSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"}, nil, scheme)
+	require.NoError(t, err)
+	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+
+	// Verify NO owner reference was added (owner was nil)
+	var updated corev1.Secret
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "test-secret", Namespace: "test"}, &updated)
+	require.NoError(t, err)
+	assert.Empty(t, updated.OwnerReferences)
+}
+
+func TestSecretManager_MultipleOwners(t *testing.T) {
+	scheme := newTestScheme()
+
+	owner1 := &metal3api.Ironic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ironic-1",
+			Namespace: "test",
+			UID:       "uid-1",
+		},
+	}
+
+	owner2 := &metal3api.Ironic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ironic-2",
+			Namespace: "test",
+			UID:       "uid-2",
+		},
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"data": []byte("value"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, owner1, owner2).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	// First owner acquires the secret
+	_, err := sm.AcquireSecret(types.NamespacedName{Name: "shared-secret", Namespace: "test"}, owner1, scheme)
+	require.NoError(t, err)
+
+	// Second owner also acquires the same secret
+	_, err = sm.AcquireSecret(types.NamespacedName{Name: "shared-secret", Namespace: "test"}, owner2, scheme)
+	require.NoError(t, err)
+
+	// Verify both owner references exist
+	var updated corev1.Secret
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "shared-secret", Namespace: "test"}, &updated)
+	require.NoError(t, err)
+	assert.Len(t, updated.OwnerReferences, 2)
+}
+
+func TestSecretManager_PreservesExistingLabels(t *testing.T) {
+	scheme := newTestScheme()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test",
+			Labels: map[string]string{
+				"existing-label": "existing-value",
+			},
+		},
+		Data: map[string][]byte{
+			"data": []byte("value"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	result, err := sm.ObtainSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"})
+	require.NoError(t, err)
+
+	// Verify both labels exist
+	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+	assert.Equal(t, "existing-value", result.Labels["existing-label"])
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the SecretManager from BMO to also handle secrets in IRSO. Instead of holding all cluster secrets in cluster client cache, we only keep the ones that match our labels. This lowers memory consumption but also prevents a risk that the cluster secrets might get dumped. This has been adapted from BMO's SecretManager.


Fixes #425

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
