### PR TITLE
🐛Fix draft release creation 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,6 +104,11 @@ jobs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: ${{ env.go_version }}
+    - name: generate release artifacts
+      run: |
+        make release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: get release notes
       run: |
         curl -L "https://raw.githubusercontent.com/${{ github.repository }}/main/releasenotes/${{ env.RELEASE_TAG }}.md" \
@@ -112,6 +117,7 @@ jobs:
       uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
       with:
         draft: true
+        files: out/*
         body_path: ${{ env.RELEASE_TAG }}.md
         tag_name: ${{ env.RELEASE_TAG }}
   build_irso:

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ bin/
 # IDE files
 .idea
 .vscode/
+
+# Release artifacts
+out/

--- a/Makefile
+++ b/Makefile
@@ -310,6 +310,10 @@ go-version: ## Print the go version we use to compile our binaries and images
 ## --------------------------------------
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
 RELEASE_NOTES_DIR := releasenotes
+RELEASE_DIR := out
+
+$(RELEASE_DIR):
+	mkdir -p $(RELEASE_DIR)/
 
 $(RELEASE_NOTES_DIR):
 	mkdir -p $(RELEASE_NOTES_DIR)/


### PR DESCRIPTION
We observed that it is failing the creation of draft release because of missing release directory and also it needs the release artifacts generation steps in this branch.
[Failed Draft release]( https://github.com/metal3-io/ironic-standalone-operator/actions/runs/19849456082/job/56873158695#step:6:23)