### PR TITLE
:seedling: Fix make lint target

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -73,9 +73,6 @@ linters:
       enabled-tags:
       - experimental
     gosec:
-      # (NOTE)elfosardo: we should try removing this exclude once we bump golangci-lint to 1.61
-      excludes:
-      - G115
       severity: medium
       confidence: medium
       concurrency: 8

--- a/Makefile
+++ b/Makefile
@@ -256,13 +256,6 @@ $(GOLANGCI_LINT): $(LOCALBIN) ## Download golangci-lint locally if necessary. If
 .PHONY: lint
 lint: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) config verify
-	$(GOLANGCI_LINT) run -v --fast-only ./... --timeout=10m
-	cd api; $(GOLANGCI_LINT) run -v --fast-only --path-prefix=api ./... --timeout=10m
-	cd test; $(GOLANGCI_LINT) run -v --fast-only --path-prefix=test ./... --timeout=10m
-
-.PHONY: lint-full
-lint-full: $(GOLANGCI_LINT)
-	$(GOLANGCI_LINT) config verify
 	$(GOLANGCI_LINT) run -v ./... --timeout=10m
 	cd api; $(GOLANGCI_LINT) run -v --path-prefix=api ./... --timeout=10m
 	cd test; $(GOLANGCI_LINT) run -v --path-prefix=test ./... --timeout=10m


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
This removes `make lint-full` target and removes `--fast-only` flag from the `make lint` target to catch all errors also locally and unify CI and local behavior. Additionally removes exclude directive from the golangci config, as the comment there suggests it should be removed. I did not notice any change in behavior when removing it, so I think it is safe to remove.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #456

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
