### PR TITLE
:sparkles: pass proxy environment variables to ramdisk-downloader

### DIFF
--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -668,6 +668,12 @@ func newIronicPodTemplate(cctx ControllerContext, resources Resources) (corev1.P
 		"IPA_BRANCH", cctx.VersionInfo.AgentBranch)
 	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
 		"IPA_BASEURI", os.Getenv("IPA_BASEURI"))
+	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
+		"HTTPS_PROXY", os.Getenv("IPA_HTTPS_PROXY"))
+	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
+		"HTTP_PROXY", os.Getenv("IPA_HTTP_PROXY"))
+	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
+		"NO_PROXY", os.Getenv("IPA_NO_PROXY"))
 
 	volumes, mounts := buildIronicVolumesAndMounts(resources)
 	sharedVolumeMount := mounts[0]


### PR DESCRIPTION
Add support to pass HTTPS_PROXY, HTTP_PROXY and NO_PROXY environment variables to the ramdisk-downloader init container. These environment variables map to IPA_HTTPS_PROXY, IPA_HTTP_PROXY and IPA_NO_PROXY customization values, respectively.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Proxy environment variables are required to enable downloading when routing requests through a designated intermediary server instead of directly to the Internet.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #308 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
