### PR TITLE
🌱Enable containedctx linter for golangcilint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,7 +8,7 @@ linters:
   - asciicheck
   - bidichk
   - bodyclose
-  #- containedctx
+  - containedctx
   - copyloopvar
   - decorder
   - dogsled

--- a/pkg/ironic/utils.go
+++ b/pkg/ironic/utils.go
@@ -31,6 +31,7 @@ const (
 	tmpVolumeName  = "ironic-tmp"
 )
 
+//nolint:containedctx // Context is intentionally stored for use throughout the controller lifecycle
 type ControllerContext struct {
 	Context     context.Context
 	Client      client.Client

--- a/pkg/secretutils/secret_manager.go
+++ b/pkg/secretutils/secret_manager.go
@@ -17,6 +17,8 @@ import (
 // SecretManager is a type for fetching Secrets whether or not they are in the
 // client cache, labelling so that they will be included in the client cache,
 // and optionally setting an owner reference.
+//
+//nolint:containedctx // Context is intentionally stored for use throughout the manager lifecycle
 type SecretManager struct {
 	ctx       context.Context
 	log       logr.Logger


### PR DESCRIPTION
Fixes #199 
Description in issue. Enabling and fixing the "containerdctx" linter issue