### PR TITLE
✨ Pass IPA_FLAVOR and IPA_ARCH env vars to ramdisk-downloader

### DIFF
--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -673,6 +673,10 @@ func newIronicPodTemplate(cctx ControllerContext, resources Resources) (corev1.P
 	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
 		"IPA_BASEURI", os.Getenv("IPA_BASEURI"))
 	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
+		"IPA_FLAVOR", os.Getenv("IPA_FLAVOR"))
+	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
+		"IPA_ARCH", os.Getenv("IPA_ARCH"))
+	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
 		"HTTPS_PROXY", os.Getenv("IPA_HTTPS_PROXY"))
 	ipaDownloaderVars = appendStringEnv(ipaDownloaderVars,
 		"HTTP_PROXY", os.Getenv("IPA_HTTP_PROXY"))


### PR DESCRIPTION
The ironic-ipa-downloader supports `IPA_FLAVOR` for selecting the distribution (centos8, centos9, debian) and `IPA_ARCH` for adding an architecture suffix to destination filenames, but the ironic-standalone-operator does not currently pass these through to the container.. 

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #534

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
