### PR TITLE
:seedling: enforce ol-prefix 'one' style for ordered lists

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,6 +4,8 @@ config:
   ul-indent:
     # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
     indent: 3
+  ol-prefix:
+    style: "one"
   line-length:
     tables: false
     code_blocks: false


### PR DESCRIPTION
We have it in metal3-io wide use except couple lists in BMO, and some old design docs, so enforcing it in config in all repos for consistency.