### PR TITLE
:seedling: specify oci platform during image build

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       image-name: 'ironic-standalone-operator'
       pushImage: true
+      platform: 'linux/amd64'
       generate-sbom: true
       sign-image: true
     secrets:


### PR DESCRIPTION
This PR:
 - specifies the oci platform during image build to 'linux/amd64'

This change is needed to resolve recent issues after the GH runner docker version was uplifted to v29. Images built by the new runners seem to produce manifests that confuse docker-ce when the user re-tags an upstream image and pushes the new tag to local registry.
