### PR TITLE
:seedling: e2e: download ipa image only once

### DIFF
--- a/config/testing/manager_irso_config_patch.yaml
+++ b/config/testing/manager_irso_config_patch.yaml
@@ -12,4 +12,4 @@ spec:
             - name: FEATURE_GATES
               value: HighAvailability=true,Overrides=true
             - name: IPA_BASEURI
-              value: https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
+              value: IRSO_IPA_BASEURI

--- a/test/prepare.sh
+++ b/test/prepare.sh
@@ -53,6 +53,21 @@ for image in ironic ironic-ipa-downloader keepalived; do
     image_pull "${image}"
 done
 
+# Predownloading IPA image and serving it locally (see #574)
+
+IPA_FILE="ipa-centos9-master.tar.gz"
+IPA_REMOTE_URI="https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib"
+
+mkdir -p "${IPA_DIR}"
+if [[ ! -f "${IPA_DIR}/${IPA_FILE}" ]]; then
+    curl -Lo "${IPA_DIR}/${IPA_FILE}" "${IPA_REMOTE_URI}/${IPA_FILE}"
+fi
+
+IPA_HOST_IP=$(ipa_host_ip)
+
+IPA_BASEURI="http://${IPA_HOST_IP}:${IPA_SERVER_PORT}"
+sed -i "s|IRSO_IPA_BASEURI|${IPA_BASEURI}|" config/testing/manager_irso_config_patch.yaml
+
 # Building and installing the operator
 
 "${CONTAINER_RUNTIME}" build -t "${IMG}" . 2>&1 | tee "${LOGDIR}/docker-build.log"

--- a/test/run.sh
+++ b/test/run.sh
@@ -10,13 +10,22 @@ JUNIT_OUTPUT="${JUNIT_OUTPUT:-${LOGDIR}/report.xml}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-90m}"
 
 . testing.env
+# shellcheck disable=SC1091
+. utils.sh
 
 mkdir -p "${LOGDIR}"
+
+# Start local IPA server (downloaded by prepare.sh)
+IPA_HOST_IP=$(ipa_host_ip)
+python3 -m http.server "${IPA_SERVER_PORT}" --bind "${IPA_HOST_IP}" --directory "${IPA_DIR}" \
+    &>"${LOGDIR}/ipa-server.log" &
+IPA_SERVER_PID=$!
+trap 'kill ${IPA_SERVER_PID} 2>/dev/null || true' EXIT
 
 declare -a EXTRA_ARGS
 if [[ -n "${LABEL_FILTER:-}" ]]; then
     EXTRA_ARGS=(--ginkgo.label-filter "${LABEL_FILTER}")
 fi
 
-exec go test --ginkgo.vv --ginkgo.junit-report "${JUNIT_OUTPUT}" -timeout "${TEST_TIMEOUT}" \
+go test --ginkgo.vv --ginkgo.junit-report "${JUNIT_OUTPUT}" -timeout "${TEST_TIMEOUT}" \
     --ginkgo.fail-on-empty "${EXTRA_ARGS[@]}"

--- a/test/testing.env
+++ b/test/testing.env
@@ -18,3 +18,6 @@ export IRONIC_KEY_FILE=/tmp/ironic-tls.key
 
 export MARIADB_NAMESPACE=mariadb
 export MARIADB_NAME=ironic-database
+
+IPA_SERVER_PORT=8089
+IPA_DIR="/tmp/ipa"

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -4,7 +4,7 @@ set -eux -o pipefail
 
 CLUSTER_TYPE="${CLUSTER_TYPE:-kind}"
 
-if [[ -z "${CONTAINER_RUNTIME}" ]]; then
+if [[ -z "${CONTAINER_RUNTIME:-}" ]]; then
     if command -v podman &> /dev/null;  then
         CONTAINER_RUNTIME=podman
     else
@@ -13,6 +13,14 @@ if [[ -z "${CONTAINER_RUNTIME}" ]]; then
 fi
 
 IMAGE_NAMESPACE="${IMAGE_NAMESPACE:-quay.io/metal3-io}"
+
+ipa_host_ip() {
+    if [[ "${CLUSTER_TYPE}" == "kind" ]]; then
+        docker network inspect kind -f '{{(index .IPAM.Config 0).Gateway}}'
+    else
+        minikube ssh -- ip route show default | awk '{print $3}'
+    fi
+}
 
 image_load() {
     local image="$1"


### PR DESCRIPTION
Host IPA image locally for upgrade testing to avoid downloading it multiple times which is error prone.

Manual cherry-pick of #575 .