### PR TITLE
🌱 Use the new IRONIC_JSON_RPC_PORT instead of an OS override

### DIFF
--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -220,10 +220,8 @@ func buildIronicEnvVars(cctx ControllerContext, resources Resources) []corev1.En
 			Name:  "IRONIC_EXPOSE_JSON_RPC",
 			Value: strconv.FormatBool(resources.Ironic.Spec.HighAvailability),
 		},
-		// NOTE(dtantsur): this is necessary for the transition process from port 8089 (conflicting with kubernetes-nmstate)
-		// to port 6189 chosen for Metal3.
 		{
-			Name:  "OS_JSON_RPC__PORT",
+			Name:  "IRONIC_JSON_RPC_PORT",
 			Value: strconv.Itoa(int(resources.Ironic.Spec.Networking.RPCPort)),
 		},
 	}...)

--- a/pkg/ironic/containers_test.go
+++ b/pkg/ironic/containers_test.go
@@ -197,8 +197,6 @@ func TestExpectedExtraEnvVars(t *testing.T) {
 		"OS_PXE__BOOT_RETRY_TIMEOUT":            "1200",
 		"OS_CONDUCTOR__DEPLOY_CALLBACK_TIMEOUT": "4800",
 		"OS_CONDUCTOR__INSPECT_TIMEOUT":         "1800",
-		// This is currently set unconditionally by IrSO itself and will eventually be replaced by a proper ironic-image variable.
-		"OS_JSON_RPC__PORT": "6189",
 	}
 
 	ironic := &metal3api.Ironic{


### PR DESCRIPTION
The new variables is already present in 32.0.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
