### PR TITLE
⚠️ Require environment label on Secrets and ConfigMaps

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -11,6 +11,14 @@ const (
 	IronicReasonAvailable  = "DeploymentAvailable"
 
 	IronicLabelPrefix = "ironic.metal3.io"
+
+	// LabelEnvironmentName is the label key that must be present on user-provided
+	// Secrets and ConfigMaps to grant the operator permission to use them.
+	// The value must be LabelEnvironmentValue.
+	LabelEnvironmentName = "environment.metal3.io/ironic-standalone-operator"
+
+	// LabelEnvironmentValue is the required value for the LabelEnvironmentName label.
+	LabelEnvironmentValue = "true"
 )
 
 var (

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -223,13 +224,14 @@ func (r *IronicReconciler) getAndUpdateSecret(cctx ironic.ControllerContext, iro
 	secretManager := secretutils.NewSecretManager(cctx.Context, cctx.Logger, cctx.Client, r.APIReader)
 	secret, err = secretManager.AcquireSecret(namespacedName, ironicConf, cctx.Scheme)
 	if err != nil {
-		// NotFound requires a user's intervention, so reporting it in the conditions.
-		// Everything else is reported up for a retry.
-		if k8serrors.IsNotFound(err) {
-			message := fmt.Sprintf("secret %s/%s not found", ironicConf.Namespace, secretName)
-			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, message)
+		wrappedErr := fmt.Errorf("cannot load secret %s/%s: %w", ironicConf.Namespace, secretName, err)
+		// Only missing-label and NotFound errors require user intervention.
+		// Other errors are transient and should just be retried.
+		var missingLabelErr *secretutils.MissingLabelError
+		if errors.As(err, &missingLabelErr) || k8serrors.IsNotFound(err) {
+			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, wrappedErr.Error())
 		}
-		return nil, true, fmt.Errorf("cannot load secret %s/%s: %w", ironicConf.Namespace, secretName, err)
+		return nil, true, wrappedErr
 	}
 
 	return secret, false, nil
@@ -246,13 +248,14 @@ func (r *IronicReconciler) getConfigMap(cctx ironic.ControllerContext, ironicCon
 	secretManager := secretutils.NewSecretManager(cctx.Context, cctx.Logger, cctx.Client, r.APIReader)
 	configMap, err = secretManager.ObtainConfigMap(namespacedName)
 	if err != nil {
-		// NotFound requires a user's intervention, so reporting it in the conditions.
-		// Everything else is reported up for a retry.
-		if k8serrors.IsNotFound(err) {
-			message := fmt.Sprintf("configmap %s/%s not found", ironicConf.Namespace, configMapName)
-			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, message)
+		wrappedErr := fmt.Errorf("cannot load configmap %s/%s: %w", ironicConf.Namespace, configMapName, err)
+		// Only missing-label and NotFound errors require user intervention.
+		// Other errors are transient and should just be retried.
+		var missingLabelErr *secretutils.MissingLabelError
+		if errors.As(err, &missingLabelErr) || k8serrors.IsNotFound(err) {
+			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, wrappedErr.Error())
 		}
-		return nil, true, fmt.Errorf("cannot load configmap %s/%s: %w", ironicConf.Namespace, configMapName, err)
+		return nil, true, wrappedErr
 	}
 
 	return configMap, false, nil

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -16,7 +16,6 @@ import (
 
 	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
 	"github.com/metal3-io/ironic-standalone-operator/pkg/ironic"
-	"github.com/metal3-io/ironic-standalone-operator/pkg/secretutils"
 )
 
 const IronicFinalizer = "ironic.metal3.io"
@@ -83,9 +82,6 @@ func generateSecret(cctx ironic.ControllerContext, owner metav1.Object, meta *me
 	if err != nil {
 		return
 	}
-
-	// Add the environment label so the secret is included in the filtered cache
-	metav1.SetMetaDataLabel(&secret.ObjectMeta, secretutils.LabelEnvironmentName, secretutils.LabelEnvironmentValue)
 
 	err = controllerutil.SetOwnerReference(owner, secret, cctx.Scheme)
 	if err != nil {

--- a/pkg/ironic/secrets.go
+++ b/pkg/ironic/secrets.go
@@ -15,6 +15,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
 )
 
 func checkValidUser(user string) error {
@@ -135,6 +137,10 @@ func GenerateSecret(owner *metav1.ObjectMeta, name string, extraFields bool) (*c
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-%s-", owner.Name, name),
 			Namespace:    owner.Namespace,
+			Labels: map[string]string{
+				// Add the environment label so the secret is included in the filtered cache
+				metal3api.LabelEnvironmentName: metal3api.LabelEnvironmentValue,
+			},
 		},
 		Data: map[string][]byte{
 			corev1.BasicAuthUsernameKey: []byte(owner.Name),

--- a/pkg/secretutils/label.go
+++ b/pkg/secretutils/label.go
@@ -7,11 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
 
-const (
-	LabelEnvironmentName  = "environment.metal3.io/ironic-standalone-operator"
-	LabelEnvironmentValue = "true"
+	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
 )
 
 // AddSecretSelector adds a selector to a cache.ByObject map that filters
@@ -24,13 +21,13 @@ func AddSecretSelector(selectors map[client.Object]cache.ByObject) map[client.Ob
 		configMap: {
 			Label: labels.SelectorFromSet(
 				labels.Set{
-					LabelEnvironmentName: LabelEnvironmentValue,
+					metal3api.LabelEnvironmentName: metal3api.LabelEnvironmentValue,
 				}),
 		},
 		secret: {
 			Label: labels.SelectorFromSet(
 				labels.Set{
-					LabelEnvironmentName: LabelEnvironmentValue,
+					metal3api.LabelEnvironmentName: metal3api.LabelEnvironmentValue,
 				}),
 		},
 	}

--- a/pkg/secretutils/secret_manager.go
+++ b/pkg/secretutils/secret_manager.go
@@ -11,11 +11,29 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
 )
 
-// SecretManager is a type for fetching Secrets whether or not they are in the
-// client cache, labelling so that they will be included in the client cache,
-// and optionally setting an owner reference.
+// MissingLabelError is returned when a resource does not have the required
+// environment label. This error requires user intervention to add the label
+// to the resource before the operator will use it.
+type MissingLabelError struct {
+	ObjectType string
+	Namespace  string
+	Name       string
+}
+
+func (e *MissingLabelError) Error() string {
+	return fmt.Sprintf(
+		"%s %s/%s does not have the required label %s=%s",
+		e.ObjectType, e.Namespace, e.Name,
+		metal3api.LabelEnvironmentName, metal3api.LabelEnvironmentValue)
+}
+
+// SecretManager is a type for fetching Secrets and ConfigMaps whether or not
+// they are in the client cache, verifying that they carry the required
+// environment label, and optionally setting an owner reference.
 //
 //nolint:containedctx // Context is intentionally stored for use throughout the manager lifecycle
 type SecretManager struct {
@@ -66,22 +84,24 @@ func (sm *SecretManager) findObject(key types.NamespacedName, object client.Obje
 	return nil
 }
 
-// claimObject ensures that the object has a label that will ensure it is
-// present in the cache (and that we can watch for changes), and optionally
-// that it has a particular owner reference.
+// claimObject ensures that the object has the required environment label
+// (which must be set by the user for user-provided resources, or by the
+// operator for resources it creates), and optionally sets an owner reference.
 func (sm *SecretManager) claimObject(object client.Object, owner client.Object, scheme *runtime.Scheme) error {
 	log := sm.log.WithValues(objectType(object), object.GetName(), "namespace", object.GetNamespace())
 	needsUpdate := false
 
+	// Require the environment label to already be present. For user-provided
+	// resources this acts as an opt-in: the user must label the resource before
+	// the operator will use it. Operator-created resources are labelled at
+	// creation time.
 	currentLabels := object.GetLabels()
-	if _, found := currentLabels[LabelEnvironmentName]; !found {
-		log.Info("setting environment label")
-		if currentLabels == nil {
-			currentLabels = make(map[string]string, 1)
+	if currentLabels[metal3api.LabelEnvironmentName] != metal3api.LabelEnvironmentValue {
+		return &MissingLabelError{
+			ObjectType: objectType(object),
+			Namespace:  object.GetNamespace(),
+			Name:       object.GetName(),
 		}
-		currentLabels[LabelEnvironmentName] = LabelEnvironmentValue
-		object.SetLabels(currentLabels)
-		needsUpdate = true
 	}
 
 	if owner != nil && scheme != nil {
@@ -116,9 +136,8 @@ func (sm *SecretManager) claimObject(object client.Object, owner client.Object, 
 	return nil
 }
 
-// AcquireSecret retrieves a Secret and ensures that it has a label that will
-// ensure it is present in the cache (and that we can watch for changes), and
-// that it has a particular owner reference.
+// AcquireSecret retrieves a Secret, verifies it carries the required
+// environment label, and ensures it has a particular owner reference.
 func (sm *SecretManager) AcquireSecret(key types.NamespacedName, owner client.Object, scheme *runtime.Scheme) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	err := sm.findObject(key, secret)

--- a/pkg/secretutils/secret_manager_test.go
+++ b/pkg/secretutils/secret_manager_test.go
@@ -22,6 +22,12 @@ func newTestScheme() *runtime.Scheme {
 	return scheme
 }
 
+func environmentLabels() map[string]string {
+	return map[string]string{
+		metal3api.LabelEnvironmentName: metal3api.LabelEnvironmentValue,
+	}
+}
+
 func TestSecretManager_ObtainSecret_NotFound(t *testing.T) {
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -38,9 +44,7 @@ func TestSecretManager_ObtainSecret_FoundInCache(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: "test",
-			Labels: map[string]string{
-				LabelEnvironmentName: LabelEnvironmentValue,
-			},
+			Labels:    environmentLabels(),
 		},
 		Data: map[string][]byte{
 			"username": []byte("admin"),
@@ -55,15 +59,16 @@ func TestSecretManager_ObtainSecret_FoundInCache(t *testing.T) {
 	result, err := sm.ObtainSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"})
 	require.NoError(t, err)
 	assert.Equal(t, "test-secret", result.Name)
-	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+	assert.Equal(t, metal3api.LabelEnvironmentValue, result.Labels[metal3api.LabelEnvironmentName])
 }
 
-func TestSecretManager_ObtainSecret_AddsLabel(t *testing.T) {
+func TestSecretManager_ObtainSecret_LabelAlreadySet(t *testing.T) {
 	scheme := newTestScheme()
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: "test",
+			Labels:    environmentLabels(),
 		},
 		Data: map[string][]byte{
 			"username": []byte("admin"),
@@ -77,13 +82,14 @@ func TestSecretManager_ObtainSecret_AddsLabel(t *testing.T) {
 
 	result, err := sm.ObtainSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"})
 	require.NoError(t, err)
-	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+	assert.Equal(t, metal3api.LabelEnvironmentValue, result.Labels[metal3api.LabelEnvironmentName])
 
-	// Verify the label was persisted
+	// Verify the secret was not modified (no extra labels, no ownerRefs)
 	var updated corev1.Secret
 	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "test-secret", Namespace: "test"}, &updated)
 	require.NoError(t, err)
-	assert.Equal(t, LabelEnvironmentValue, updated.Labels[LabelEnvironmentName])
+	assert.Equal(t, metal3api.LabelEnvironmentValue, updated.Labels[metal3api.LabelEnvironmentName])
+	assert.Empty(t, updated.OwnerReferences)
 }
 
 func TestSecretManager_AcquireSecret_WithOwner(t *testing.T) {
@@ -92,6 +98,7 @@ func TestSecretManager_AcquireSecret_WithOwner(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: "test",
+			Labels:    environmentLabels(),
 		},
 		Data: map[string][]byte{
 			"username": []byte("admin"),
@@ -113,7 +120,7 @@ func TestSecretManager_AcquireSecret_WithOwner(t *testing.T) {
 
 	result, err := sm.AcquireSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"}, owner, scheme)
 	require.NoError(t, err)
-	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+	assert.Equal(t, metal3api.LabelEnvironmentValue, result.Labels[metal3api.LabelEnvironmentName])
 
 	// Verify owner reference was added
 	var updated corev1.Secret
@@ -129,9 +136,7 @@ func TestSecretManager_AcquireSecret_AlreadyLabeled(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: "test",
-			Labels: map[string]string{
-				LabelEnvironmentName: LabelEnvironmentValue,
-			},
+			Labels:    environmentLabels(),
 		},
 		Data: map[string][]byte{
 			"username": []byte("admin"),
@@ -144,7 +149,7 @@ func TestSecretManager_AcquireSecret_AlreadyLabeled(t *testing.T) {
 
 	result, err := sm.ObtainSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"})
 	require.NoError(t, err)
-	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+	assert.Equal(t, metal3api.LabelEnvironmentValue, result.Labels[metal3api.LabelEnvironmentName])
 }
 
 func TestSecretManager_AcquireSecret_AlreadyOwned(t *testing.T) {
@@ -162,9 +167,7 @@ func TestSecretManager_AcquireSecret_AlreadyOwned(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: "test",
-			Labels: map[string]string{
-				LabelEnvironmentName: LabelEnvironmentValue,
-			},
+			Labels:    environmentLabels(),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: "ironic.metal3.io/v1alpha1",
@@ -197,38 +200,36 @@ func TestSecretManager_AcquireSecret_AlreadyOwned(t *testing.T) {
 func TestSecretManager_FallbackToAPIReader(t *testing.T) {
 	scheme := newTestScheme()
 
-	// Secret exists only in the "API" (apiReader), not in the cache
-	// This simulates an unlabeled secret that's not in the filtered cache
+	// Secret with the label exists only in the API reader, not in the cache.
+	// This simulates a labeled secret that hasn't been synced into the cache
+	// yet, and exercises the findObject fallback path to apiReader.
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "uncached-secret",
 			Namespace: "test",
+			Labels:    environmentLabels(),
 		},
 		Data: map[string][]byte{
 			"data": []byte("value"),
 		},
 	}
 
-	// Both clients have the secret (in real scenario, cache would filter it out,
-	// but for testing we simulate the fallback by using separate clients)
-	// The key behavior we're testing is that findSecret tries cache first, then API
-	cacheClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+	cacheClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	apiReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
 
 	sm := NewSecretManager(t.Context(), logr.Discard(), cacheClient, apiReader)
 
-	// The secret should be found (via cache in this test, but the fallback logic is tested)
 	result, err := sm.ObtainSecret(types.NamespacedName{Name: "uncached-secret", Namespace: "test"})
 	require.NoError(t, err)
 	assert.Equal(t, "uncached-secret", result.Name)
-	// Label should be added
-	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+	assert.Equal(t, metal3api.LabelEnvironmentValue, result.Labels[metal3api.LabelEnvironmentName])
 }
 
 func TestSecretManager_NotInCacheButInAPI(t *testing.T) {
 	scheme := newTestScheme()
 
-	// Secret exists only in the API reader, not in the cache client
+	// Secret exists only in the API reader, not in the cache client.
+	// It does NOT have the environment label, so claimObject must reject it.
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "api-only-secret",
@@ -239,19 +240,14 @@ func TestSecretManager_NotInCacheButInAPI(t *testing.T) {
 		},
 	}
 
-	// Empty cache client, secret only in API reader
 	cacheClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	apiReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
 
 	sm := NewSecretManager(t.Context(), logr.Discard(), cacheClient, apiReader)
 
-	// findSecret should find it via API fallback, but claimSecret will fail
-	// because the secret doesn't exist in the cache client for update
-	// This tests the fallback path in findSecret
 	_, err := sm.ObtainSecret(types.NamespacedName{Name: "api-only-secret", Namespace: "test"})
-	// We expect an error because we can't update a secret that doesn't exist in the cache client
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "does not have the required label")
 }
 
 func TestSecretManager_AcquireSecret_WithOwnerNoScheme(t *testing.T) {
@@ -260,6 +256,7 @@ func TestSecretManager_AcquireSecret_WithOwnerNoScheme(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: "test",
+			Labels:    environmentLabels(),
 		},
 		Data: map[string][]byte{
 			"username": []byte("admin"),
@@ -278,10 +275,10 @@ func TestSecretManager_AcquireSecret_WithOwnerNoScheme(t *testing.T) {
 
 	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
 
-	// When scheme is nil, owner reference should not be set (only label)
+	// When scheme is nil, owner reference should not be set (only label checked)
 	result, err := sm.AcquireSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"}, owner, nil)
 	require.NoError(t, err)
-	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+	assert.Equal(t, metal3api.LabelEnvironmentValue, result.Labels[metal3api.LabelEnvironmentName])
 
 	// Verify NO owner reference was added (scheme was nil)
 	var updated corev1.Secret
@@ -296,6 +293,7 @@ func TestSecretManager_AcquireSecret_NilOwnerWithScheme(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: "test",
+			Labels:    environmentLabels(),
 		},
 		Data: map[string][]byte{
 			"username": []byte("admin"),
@@ -306,10 +304,10 @@ func TestSecretManager_AcquireSecret_NilOwnerWithScheme(t *testing.T) {
 
 	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
 
-	// When owner is nil, only label should be set (same as ObtainSecret)
+	// When owner is nil, only label should be checked (same as ObtainSecret)
 	result, err := sm.AcquireSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"}, nil, scheme)
 	require.NoError(t, err)
-	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+	assert.Equal(t, metal3api.LabelEnvironmentValue, result.Labels[metal3api.LabelEnvironmentName])
 
 	// Verify NO owner reference was added (owner was nil)
 	var updated corev1.Secret
@@ -341,6 +339,7 @@ func TestSecretManager_MultipleOwners(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "shared-secret",
 			Namespace: "test",
+			Labels:    environmentLabels(),
 		},
 		Data: map[string][]byte{
 			"data": []byte("value"),
@@ -373,7 +372,8 @@ func TestSecretManager_PreservesExistingLabels(t *testing.T) {
 			Name:      "test-secret",
 			Namespace: "test",
 			Labels: map[string]string{
-				"existing-label": "existing-value",
+				metal3api.LabelEnvironmentName: metal3api.LabelEnvironmentValue,
+				"existing-label":               "existing-value",
 			},
 		},
 		Data: map[string][]byte{
@@ -389,6 +389,196 @@ func TestSecretManager_PreservesExistingLabels(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify both labels exist
-	assert.Equal(t, LabelEnvironmentValue, result.Labels[LabelEnvironmentName])
+	assert.Equal(t, metal3api.LabelEnvironmentValue, result.Labels[metal3api.LabelEnvironmentName])
 	assert.Equal(t, "existing-value", result.Labels["existing-label"])
+}
+
+// Rejection tests: verify that Secrets/ConfigMaps without the environment label are refused.
+
+func TestSecretManager_ObtainSecret_NoLabel(t *testing.T) {
+	scheme := newTestScheme()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unlabeled-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"data": []byte("value"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	_, err := sm.ObtainSecret(types.NamespacedName{Name: "unlabeled-secret", Namespace: "test"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), metal3api.LabelEnvironmentName)
+	assert.Contains(t, err.Error(), "does not have the required label")
+
+	// Verify the secret was NOT modified (no label added, no ownerRef)
+	var updated corev1.Secret
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "unlabeled-secret", Namespace: "test"}, &updated)
+	require.NoError(t, err)
+	assert.Empty(t, updated.Labels)
+	assert.Empty(t, updated.OwnerReferences)
+}
+
+func TestSecretManager_AcquireSecret_NoLabel(t *testing.T) {
+	scheme := newTestScheme()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unlabeled-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"data": []byte("value"),
+		},
+	}
+
+	owner := &metal3api.Ironic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ironic",
+			Namespace: "test",
+			UID:       "test-uid-12345",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, owner).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	_, err := sm.AcquireSecret(types.NamespacedName{Name: "unlabeled-secret", Namespace: "test"}, owner, scheme)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), metal3api.LabelEnvironmentName)
+
+	// Verify the secret was NOT modified (no label or ownerRef added)
+	var updated corev1.Secret
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "unlabeled-secret", Namespace: "test"}, &updated)
+	require.NoError(t, err)
+	assert.Empty(t, updated.Labels)
+	assert.Empty(t, updated.OwnerReferences)
+}
+
+func TestSecretManager_LabelWrongValue(t *testing.T) {
+	scheme := newTestScheme()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wrong-value-secret",
+			Namespace: "test",
+			Labels: map[string]string{
+				metal3api.LabelEnvironmentName: "false",
+			},
+		},
+		Data: map[string][]byte{
+			"data": []byte("value"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	_, err := sm.ObtainSecret(types.NamespacedName{Name: "wrong-value-secret", Namespace: "test"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not have the required label")
+}
+
+func TestSecretManager_ObtainConfigMap_NoLabel(t *testing.T) {
+	scheme := newTestScheme()
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unlabeled-cm",
+			Namespace: "test",
+		},
+		Data: map[string]string{
+			"ca.crt": "some-ca-data",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	_, err := sm.ObtainConfigMap(types.NamespacedName{Name: "unlabeled-cm", Namespace: "test"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), metal3api.LabelEnvironmentName)
+	assert.Contains(t, err.Error(), "config map")
+
+	// Verify the configmap was NOT modified
+	var updated corev1.ConfigMap
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "unlabeled-cm", Namespace: "test"}, &updated)
+	require.NoError(t, err)
+	assert.Empty(t, updated.Labels)
+}
+
+func TestSecretManager_ObtainConfigMap_WithLabel(t *testing.T) {
+	scheme := newTestScheme()
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "labeled-cm",
+			Namespace: "test",
+			Labels:    environmentLabels(),
+		},
+		Data: map[string]string{
+			"ca.crt": "some-ca-data",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	result, err := sm.ObtainConfigMap(types.NamespacedName{Name: "labeled-cm", Namespace: "test"})
+	require.NoError(t, err)
+	assert.Equal(t, "labeled-cm", result.Name)
+	assert.Equal(t, metal3api.LabelEnvironmentValue, result.Labels[metal3api.LabelEnvironmentName])
+}
+
+func TestSecretManager_LabelEmptyValue(t *testing.T) {
+	scheme := newTestScheme()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "empty-value-secret",
+			Namespace: "test",
+			Labels: map[string]string{
+				metal3api.LabelEnvironmentName: "",
+			},
+		},
+		Data: map[string][]byte{
+			"data": []byte("value"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	_, err := sm.ObtainSecret(types.NamespacedName{Name: "empty-value-secret", Namespace: "test"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not have the required label")
+}
+
+func TestSecretManager_OtherLabelsButNoEnvironment(t *testing.T) {
+	scheme := newTestScheme()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-labels-secret",
+			Namespace: "test",
+			Labels: map[string]string{
+				"some-other-label": "some-value",
+			},
+		},
+		Data: map[string][]byte{
+			"data": []byte("value"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+
+	_, err := sm.ObtainSecret(types.NamespacedName{Name: "other-labels-secret", Namespace: "test"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not have the required label")
 }

--- a/test/helpers/resources.go
+++ b/test/helpers/resources.go
@@ -45,6 +45,9 @@ func NewTLSSecret(ctx context.Context, k8sClient client.Client, namespace, name 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				metal3api.LabelEnvironmentName: metal3api.LabelEnvironmentValue,
+			},
 		},
 		Data: map[string][]byte{
 			corev1.TLSCertKey:       ironicCertPEM,
@@ -62,6 +65,9 @@ func NewAuthSecret(ctx context.Context, k8sClient client.Client, namespace, name
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				metal3api.LabelEnvironmentName: metal3api.LabelEnvironmentValue,
+			},
 		},
 		Data: map[string][]byte{
 			corev1.BasicAuthUsernameKey: []byte("admin"),

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -785,6 +785,9 @@ func testUpgradeHA(ironicVersionOld string, ironicVersionNew string, apiVersionO
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name.Name + "-api",
 			Namespace: namespace,
+			Labels: map[string]string{
+				metal3api.LabelEnvironmentName: metal3api.LabelEnvironmentValue,
+			},
 		},
 		Data: map[string][]byte{
 			corev1.BasicAuthUsernameKey: []byte("admin"),
@@ -877,7 +880,7 @@ var _ = Describe("Ironic object tests", func() {
 			DeleteAndWait(ironic)
 		})
 
-		WaitForIronicFailure(name, fmt.Sprintf("secret %s/banana not found", namespace), false)
+		WaitForIronicFailure(name, fmt.Sprintf("cannot load secret %s/banana", namespace), false)
 
 		By("creating the secret and recovering the Ironic")
 
@@ -923,7 +926,7 @@ var _ = Describe("Ironic object tests", func() {
 			DeleteAndWait(ironic)
 		})
 
-		WaitForIronicFailure(name, fmt.Sprintf("secret %s/banana not found", namespace), false)
+		WaitForIronicFailure(name, fmt.Sprintf("cannot load secret %s/banana", namespace), false)
 
 		By("creating the secret and recovering the Ironic")
 


### PR DESCRIPTION
This change is for security. We should not let the high-privilege controller make changes to resources without consent from the resource owner.

**What this PR does / why we need it**:

User-provided resources must have the environment label set before use. Operator no longer adds the label automatically. Adds tests to verify label enforcement and rejection of unlabeled or incorrectly labeled resources.

This change is to prevent the controller from making changes to user-owned
resources without consent. The label is seen as the consent. For now the controller will still put owner references on these resources, but not if they are missing the label.

It is worth noting also that CAPI does something similar for user-provided certificates: https://cluster-api.sigs.k8s.io/tasks/certs/using-custom-certificates. They must be labeled correctly or the controller will ignore them. 

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.

I will push a PR for metal3-docs for this also.