### PR TITLE
 📖 Added instructions to run controller locally on kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@ guide for more details:
 * [Introduction and architecture](https://book.metal3.io/irso/introduction)
 * [Installing Ironic](https://book.metal3.io/irso/install-basics)
 * [API reference](docs/api.md)
+* [Run controller locally on kind](docs/run-controller-local-kind.md)
 
 [ironic]: https://ironicbaremetal.org/

--- a/docs/run-controller-local-kind.md
+++ b/docs/run-controller-local-kind.md
@@ -1,7 +1,14 @@
 # Run controller locally on kind
 
-Use this flow when developing the controller while targeting a local Kubernetes
-cluster created with [kind](https://kind.sigs.k8s.io/).
+Use this flow when you want a **fast feedback loop** while developing the
+controller (e.g. debugging reconciliation logic, iterating on controller code,
+watching logs/events) against a local Kubernetes cluster created with
+[kind](https://kind.sigs.k8s.io/).
+
+For full end-to-end coverage, use the functional test harness
+(`./test/prepare.sh` + `./test/run.sh`). That path deploys IrSO into the cluster
+and also installs extra dependencies (e.g. cert-manager, MariaDB operator),
+which is great for E2E but typically much slower to iterate on.
 
 ## Prerequisites
 

--- a/docs/run-controller-local-kind.md
+++ b/docs/run-controller-local-kind.md
@@ -1,0 +1,60 @@
+# Run controller locally on kind
+
+Use this flow when developing the controller while targeting a local Kubernetes
+cluster created with [kind](https://kind.sigs.k8s.io/).
+
+## Prerequisites
+
+- `go`
+- `kubectl`
+- `kind`
+- `make`
+
+## Steps
+
+1. Create a local cluster:
+
+   ```bash
+   kind create cluster --name irso-dev
+   ```
+
+1. Point kubectl to the kind context and confirm it:
+
+   ```bash
+   kubectl config use-context kind-irso-dev
+   kubectl cluster-info
+   ```
+
+1. Install CRDs:
+
+   ```bash
+   make install
+   ```
+
+1. Run the controller locally (outside the cluster):
+
+   ```bash
+   make run RUNARGS="--webhook-port=0 --leader-elect=false"
+   ```
+
+1. (Optional) Apply the sample Ironic resource:
+
+   ```bash
+   kubectl apply -f config/samples/v1alpha1_ironic.yaml
+   ```
+
+1. Verify resources:
+
+   ```bash
+   kubectl get crd | grep ironics.ironic.metal3.io
+   kubectl get ironic -A
+   ```
+
+   To stop the controller, press `Ctrl+C` in the terminal where `make run` is
+running. 
+
+1. Delete the kind cluster:
+
+   ```bash
+   kind delete cluster --name irso-dev
+   ```

--- a/docs/run-controller-local-kind.md
+++ b/docs/run-controller-local-kind.md
@@ -58,7 +58,7 @@ which is great for E2E but typically much slower to iterate on.
    ```
 
    To stop the controller, press `Ctrl+C` in the terminal where `make run` is
-running. 
+running.
 
 1. Delete the kind cluster:
 


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
This PR adds documentation and instructions for running the Ironic Standalone Operator controller locally on a Kind cluster. This simplifies local development and testing, making it easier to validate changes without deploying to a full cluster.

Why we need it:
Developers currently have limited guidance for running the controller locally, which slows down testing and debugging. These instructions provide a reproducible workflow for local development.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #623 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
