### PR TITLE
✨ Create events when reconcile objects

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,11 +27,8 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme" //nolint:goimports // blank import with comment causes formatter conflict
-
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // k8s client auth plugins (Azure, GCP, OIDC, etc.)
 	"k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -211,7 +208,7 @@ func main() {
 		Log:           ctrl.Log.WithName("controllers").WithName("Ironic"),
 		Domain:        clusterDomain,
 		VersionInfo:   versionInfo,
-		EventRecorder: mgr.GetEventRecorderFor("ironic-controller"),
+		EventRecorder: mgr.GetEventRecorder("ironic-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Ironic")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme" //nolint:goimports // blank import with comment causes formatter conflict
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -203,13 +204,14 @@ func main() {
 	}
 
 	if err = (&controller.IronicReconciler{
-		Client:      mgr.GetClient(),
-		KubeClient:  kubeClient,
-		APIReader:   mgr.GetAPIReader(),
-		Scheme:      mgr.GetScheme(),
-		Log:         ctrl.Log.WithName("controllers").WithName("Ironic"),
-		Domain:      clusterDomain,
-		VersionInfo: versionInfo,
+		Client:        mgr.GetClient(),
+		KubeClient:    kubeClient,
+		APIReader:     mgr.GetAPIReader(),
+		Scheme:        mgr.GetScheme(),
+		Log:           ctrl.Log.WithName("controllers").WithName("Ironic"),
+		Domain:        clusterDomain,
+		VersionInfo:   versionInfo,
+		EventRecorder: mgr.GetEventRecorderFor("ironic-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Ironic")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,6 +16,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -62,9 +62,8 @@ const (
 	eventReasonIronicReady       = "IronicReady"
 	eventReasonIronicNotReady    = "IronicNotReady"
 	eventReasonInvalidLinkedRes  = "InvalidLinkedResource"
-	eventReasonSecretNotFound    = "SecretNotFound"
-	eventReasonConfigMapNotFound = "ConfigMapNotFound"
 	eventReasonAPISecretCreated  = "APISecretCreated"
+	eventActionReconciling       = "Reconciling"
 )
 
 //+kubebuilder:rbac:groups=ironic.metal3.io,resources=ironics,verbs=get;list;watch;create;update;patch;delete
@@ -126,6 +125,13 @@ func (r *IronicReconciler) setNotReady(cctx ironic.ControllerContext, ironicConf
 	return err
 }
 
+func (r *IronicReconciler) recordEventf(regarding runtime.Object, related runtime.Object, eventtype, reason, note string, args ...interface{}) {
+	if r.EventRecorder == nil {
+		return
+	}
+	r.EventRecorder.Eventf(regarding, related, eventtype, reason, eventActionReconciling, note, args...)
+}
+
 func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicConf *metal3api.Ironic) (requeue bool, err error) {
 	if ironicConf.DeletionTimestamp.IsZero() {
 		requeue, err = ensureFinalizer(cctx, ironicConf)
@@ -140,7 +146,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 	if err != nil {
 		// This condition requires a user's intervention
 		_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, err.Error())
-		r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonVersionError, eventReasonVersionError, "Failed to process version: %v", err)
+		r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonVersionError, "Failed to process version: %v", err)
 		return true, err
 	}
 	cctx.VersionInfo = versionInfo
@@ -160,7 +166,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 			if !parsedVersion.IsLatest() && cctx.VersionInfo.InstalledVersion.Compare(parsedVersion) < 0 {
 				cctx.Logger.Info("refusing to downgrade Ironic", "InstalledVersion", ironicConf.Status.InstalledVersion, "RequestedVersion", actuallyRequestedVersion)
 				_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, "Ironic does not support downgrades with an external database")
-				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonDowngradeRejected, eventReasonDowngradeRejected, "Downgrade from %s to %s is not supported with external database", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
+				r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonDowngradeRejected, "Downgrade from %s to %s is not supported with external database", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
 				return false, nil
 			}
 		}
@@ -170,7 +176,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 		if err != nil {
 			return requeue, err
 		}
-		r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, eventReasonVersionChange, eventReasonVersionChange, "Version change requested from %s to %s", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
+		r.recordEventf(ironicConf, nil, corev1.EventTypeNormal, eventReasonVersionChange, "Version change requested from %s to %s", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
 	}
 
 	apiSecret, requeue, err := r.ensureAPISecret(cctx, ironicConf)
@@ -253,14 +259,14 @@ func (r *IronicReconciler) updateIronicStatus(cctx ironic.ControllerContext, iro
 		err := cctx.Client.Status().Update(cctx.Context, ironicConf)
 		if err == nil {
 			if newReady && !oldReady {
-				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, eventReasonIronicReady, eventReasonIronicReady, "Ironic deployment is now ready")
+				r.recordEventf(ironicConf, nil, corev1.EventTypeNormal, eventReasonIronicReady, "Ironic deployment is now ready")
 			} else if !newReady && oldReady {
 				readyCond := meta.FindStatusCondition(newStatus.Conditions, string(metal3api.IronicStatusReady))
 				msg := status.String()
 				if readyCond != nil {
 					msg = readyCond.Message
 				}
-				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonIronicNotReady, eventReasonIronicNotReady, "%s", msg)
+				r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonIronicNotReady, "%s", msg)
 			}
 		}
 		return requeue, err
@@ -287,9 +293,9 @@ func (r *IronicReconciler) getAndUpdateSecret(cctx ironic.ControllerContext, iro
 		if errors.As(err, &missingLabelErr) || k8serrors.IsNotFound(err) {
 			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, wrappedErr.Error())
 			if errors.As(err, &missingLabelErr) {
-				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, eventReasonInvalidLinkedRes, "secret %s/%s is invalid: %v", ironicConf.Namespace, secretName, err)
+				r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, "secret %s/%s is invalid: %v", ironicConf.Namespace, secretName, err)
 			} else if k8serrors.IsNotFound(err) {
-				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonSecretNotFound, eventReasonSecretNotFound, "secret %s/%s not found", ironicConf.Namespace, secretName)
+				r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, "secret %s/%s not found", ironicConf.Namespace, secretName)
 			}
 		}
 		return nil, true, wrappedErr
@@ -316,9 +322,9 @@ func (r *IronicReconciler) getConfigMap(cctx ironic.ControllerContext, ironicCon
 		if errors.As(err, &missingLabelErr) || k8serrors.IsNotFound(err) {
 			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, wrappedErr.Error())
 			if errors.As(err, &missingLabelErr) {
-				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, eventReasonInvalidLinkedRes, "configmap %s/%s is invalid: %v", ironicConf.Namespace, configMapName, err)
+				r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, "configmap %s/%s is invalid: %v", ironicConf.Namespace, configMapName, err)
 			} else if k8serrors.IsNotFound(err) {
-				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonConfigMapNotFound, eventReasonConfigMapNotFound, "configmap %s/%s not found", ironicConf.Namespace, configMapName)
+				r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, "configmap %s/%s not found", ironicConf.Namespace, configMapName)
 			}
 		}
 		return nil, true, wrappedErr
@@ -342,7 +348,7 @@ func (r *IronicReconciler) ensureAPISecret(cctx ironic.ControllerContext, ironic
 			// Considering this a transient error
 			return nil, true, fmt.Errorf("cannot update the new API credentials secret: %w", err)
 		}
-		r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, eventReasonAPISecretCreated, eventReasonAPISecretCreated, "Created new API credentials secret: %s", apiSecret.Name)
+		r.recordEventf(ironicConf, nil, corev1.EventTypeNormal, eventReasonAPISecretCreated, "Created new API credentials secret: %s", apiSecret.Name)
 
 		requeue = true
 		return apiSecret, requeue, err

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,12 +45,13 @@ import (
 // IronicReconciler reconciles a Ironic object.
 type IronicReconciler struct {
 	client.Client
-	KubeClient  kubernetes.Interface
-	APIReader   client.Reader
-	Scheme      *runtime.Scheme
-	Log         logr.Logger
-	Domain      string
-	VersionInfo ironic.VersionInfo
+	KubeClient    kubernetes.Interface
+	APIReader     client.Reader
+	Scheme        *runtime.Scheme
+	Log           logr.Logger
+	Domain        string
+	VersionInfo   ironic.VersionInfo
+	EventRecorder record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=ironic.metal3.io,resources=ironics,verbs=get;list;watch;create;update;patch;delete
@@ -64,6 +66,7 @@ type IronicReconciler struct {
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -86,9 +89,13 @@ func (r *IronicReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
+	// Record event for reconciliation start
+	r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "Reconciling", "Starting reconciliation")
+
 	changed, err := r.handleIronic(cctx, ironicConf)
 	if err != nil {
 		cctx.Logger.Error(err, "reconcile failed, will retry")
+		r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "ReconcileFailed", fmt.Sprintf("Reconciliation failed: %v", err))
 		return ctrl.Result{}, err
 	}
 	if changed {
@@ -96,6 +103,7 @@ func (r *IronicReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	logger.Info("object has been fully reconciled")
+	r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "Reconciled", "Object has been fully reconciled")
 	return ctrl.Result{}, nil
 }
 
@@ -124,6 +132,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 	if err != nil {
 		// This condition requires a user's intervention
 		_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, err.Error())
+		r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "VersionError", fmt.Sprintf("Failed to process version: %v", err))
 		return true, err
 	}
 	cctx.VersionInfo = versionInfo
@@ -143,6 +152,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 			if !parsedVersion.IsLatest() && cctx.VersionInfo.InstalledVersion.Compare(parsedVersion) < 0 {
 				cctx.Logger.Info("refusing to downgrade Ironic", "InstalledVersion", ironicConf.Status.InstalledVersion, "RequestedVersion", actuallyRequestedVersion)
 				_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, "Ironic does not support downgrades with an external database")
+				r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "DowngradeRejected", fmt.Sprintf("Downgrade from %s to %s is not supported with external database", ironicConf.Status.InstalledVersion, actuallyRequestedVersion))
 				return false, nil
 			}
 		}
@@ -152,10 +162,14 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 		if err != nil {
 			return requeue, err
 		}
+		r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "VersionChange", fmt.Sprintf("Version change requested from %s to %s", ironicConf.Status.InstalledVersion, actuallyRequestedVersion))
 	}
 
 	apiSecret, requeue, err := r.ensureAPISecret(cctx, ironicConf)
 	if requeue || err != nil {
+		if err != nil {
+			r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "APISecretError", fmt.Sprintf("Failed to ensure API secret: %v", err))
+		}
 		return requeue, err
 	}
 
@@ -212,20 +226,35 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 	status, err := ironic.EnsureIronic(cctx, resources)
 	if err != nil {
 		cctx.Logger.Error(err, "potentially transient error, will retry")
+		r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "EnsureIronicFailed", fmt.Sprintf("Failed to ensure Ironic resources: %v", err))
 		return requeue, err
 	}
 
 	newStatus := ironicConf.Status.DeepCopy()
+	oldReady := isStatusReady(&ironicConf.Status)
 	setConditionsFromStatus(cctx, status, &newStatus.Conditions, ironicConf.Generation, "ironic")
 	requeue = status.NeedsRequeue()
 	if status.IsReady() {
 		newStatus.InstalledVersion = actuallyRequestedVersion
 	}
+	newReady := isStatusReady(newStatus)
 
 	if !apiequality.Semantic.DeepEqual(newStatus, &ironicConf.Status) {
 		cctx.Logger.Info("updating status", "Status", newStatus)
 		ironicConf.Status = *newStatus
 		err = cctx.Client.Status().Update(cctx.Context, ironicConf)
+		if err == nil {
+			// Record events for status changes
+			if newReady && !oldReady {
+				r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "IronicReady", "Ironic deployment is now ready")
+			} else if !newReady && oldReady {
+				r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "IronicNotReady", status.String())
+			} else if status.IsError() {
+				r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "IronicError", status.String())
+			} else if !status.IsReady() {
+				r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "IronicInProgress", status.String())
+			}
+		}
 	}
 	return requeue, err
 }
@@ -243,11 +272,12 @@ func (r *IronicReconciler) getAndUpdateSecret(cctx ironic.ControllerContext, iro
 	secret, err = secretManager.AcquireSecret(namespacedName, ironicConf, cctx.Scheme)
 	if err != nil {
 		wrappedErr := fmt.Errorf("cannot load secret %s/%s: %w", ironicConf.Namespace, secretName, err)
-		// Only missing-label and NotFound errors require user intervention.
-		// Other errors are transient and should just be retried.
 		var missingLabelErr *secretutils.MissingLabelError
 		if errors.As(err, &missingLabelErr) || k8serrors.IsNotFound(err) {
 			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, wrappedErr.Error())
+		}
+		if k8serrors.IsNotFound(err) {
+			r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "SecretNotFound", fmt.Sprintf("secret %s/%s not found", ironicConf.Namespace, secretName))
 		}
 		return nil, true, wrappedErr
 	}
@@ -267,11 +297,12 @@ func (r *IronicReconciler) getConfigMap(cctx ironic.ControllerContext, ironicCon
 	configMap, err = secretManager.ObtainConfigMap(namespacedName)
 	if err != nil {
 		wrappedErr := fmt.Errorf("cannot load configmap %s/%s: %w", ironicConf.Namespace, configMapName, err)
-		// Only missing-label and NotFound errors require user intervention.
-		// Other errors are transient and should just be retried.
 		var missingLabelErr *secretutils.MissingLabelError
 		if errors.As(err, &missingLabelErr) || k8serrors.IsNotFound(err) {
 			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, wrappedErr.Error())
+		}
+		if k8serrors.IsNotFound(err) {
+			r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "ConfigMapNotFound", fmt.Sprintf("configmap %s/%s not found", ironicConf.Namespace, configMapName))
 		}
 		return nil, true, wrappedErr
 	}
@@ -294,6 +325,7 @@ func (r *IronicReconciler) ensureAPISecret(cctx ironic.ControllerContext, ironic
 			// Considering this a transient error
 			return nil, true, fmt.Errorf("cannot update the new API credentials secret: %w", err)
 		}
+		r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "APISecretCreated", fmt.Sprintf("Created new API credentials secret: %s", apiSecret.Name))
 
 		requeue = true
 		return apiSecret, requeue, err

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -125,11 +125,11 @@ func (r *IronicReconciler) setNotReady(cctx ironic.ControllerContext, ironicConf
 	return err
 }
 
-func (r *IronicReconciler) recordEventf(regarding runtime.Object, related runtime.Object, eventtype, reason, note string, args ...interface{}) {
+func (r *IronicReconciler) recordEventf(regarding runtime.Object, eventType, reason, note string, args ...interface{}) {
 	if r.EventRecorder == nil {
 		return
 	}
-	r.EventRecorder.Eventf(regarding, related, eventtype, reason, eventActionReconciling, note, args...)
+	r.EventRecorder.Eventf(regarding, nil, eventType, reason, eventActionReconciling, note, args...)
 }
 
 func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicConf *metal3api.Ironic) (requeue bool, err error) {
@@ -146,7 +146,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 	if err != nil {
 		// This condition requires a user's intervention
 		_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, err.Error())
-		r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonVersionError, "Failed to process version: %v", err)
+		r.recordEventf(ironicConf, corev1.EventTypeWarning, eventReasonVersionError, "Failed to process version: %v", err)
 		return true, err
 	}
 	cctx.VersionInfo = versionInfo
@@ -166,7 +166,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 			if !parsedVersion.IsLatest() && cctx.VersionInfo.InstalledVersion.Compare(parsedVersion) < 0 {
 				cctx.Logger.Info("refusing to downgrade Ironic", "InstalledVersion", ironicConf.Status.InstalledVersion, "RequestedVersion", actuallyRequestedVersion)
 				_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, "Ironic does not support downgrades with an external database")
-				r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonDowngradeRejected, "Downgrade from %s to %s is not supported with external database", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
+				r.recordEventf(ironicConf, corev1.EventTypeWarning, eventReasonDowngradeRejected, "Downgrade from %s to %s is not supported with external database", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
 				return false, nil
 			}
 		}
@@ -176,7 +176,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 		if err != nil {
 			return requeue, err
 		}
-		r.recordEventf(ironicConf, nil, corev1.EventTypeNormal, eventReasonVersionChange, "Version change requested from %s to %s", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
+		r.recordEventf(ironicConf, corev1.EventTypeNormal, eventReasonVersionChange, "Version change requested from %s to %s", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
 	}
 
 	apiSecret, requeue, err := r.ensureAPISecret(cctx, ironicConf)
@@ -259,14 +259,14 @@ func (r *IronicReconciler) updateIronicStatus(cctx ironic.ControllerContext, iro
 		err := cctx.Client.Status().Update(cctx.Context, ironicConf)
 		if err == nil {
 			if newReady && !oldReady {
-				r.recordEventf(ironicConf, nil, corev1.EventTypeNormal, eventReasonIronicReady, "Ironic deployment is now ready")
+				r.recordEventf(ironicConf, corev1.EventTypeNormal, eventReasonIronicReady, "Ironic deployment is now ready")
 			} else if !newReady && oldReady {
 				readyCond := meta.FindStatusCondition(newStatus.Conditions, string(metal3api.IronicStatusReady))
 				msg := status.String()
 				if readyCond != nil {
 					msg = readyCond.Message
 				}
-				r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonIronicNotReady, "%s", msg)
+				r.recordEventf(ironicConf, corev1.EventTypeWarning, eventReasonIronicNotReady, "%s", msg)
 			}
 		}
 		return requeue, err
@@ -293,9 +293,9 @@ func (r *IronicReconciler) getAndUpdateSecret(cctx ironic.ControllerContext, iro
 		if errors.As(err, &missingLabelErr) || k8serrors.IsNotFound(err) {
 			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, wrappedErr.Error())
 			if errors.As(err, &missingLabelErr) {
-				r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, "secret %s/%s is invalid: %v", ironicConf.Namespace, secretName, err)
+				r.recordEventf(ironicConf, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, "secret %s/%s is invalid: %v", ironicConf.Namespace, secretName, err)
 			} else if k8serrors.IsNotFound(err) {
-				r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, "secret %s/%s not found", ironicConf.Namespace, secretName)
+				r.recordEventf(ironicConf, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, "secret %s/%s not found", ironicConf.Namespace, secretName)
 			}
 		}
 		return nil, true, wrappedErr
@@ -322,9 +322,9 @@ func (r *IronicReconciler) getConfigMap(cctx ironic.ControllerContext, ironicCon
 		if errors.As(err, &missingLabelErr) || k8serrors.IsNotFound(err) {
 			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, wrappedErr.Error())
 			if errors.As(err, &missingLabelErr) {
-				r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, "configmap %s/%s is invalid: %v", ironicConf.Namespace, configMapName, err)
+				r.recordEventf(ironicConf, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, "configmap %s/%s is invalid: %v", ironicConf.Namespace, configMapName, err)
 			} else if k8serrors.IsNotFound(err) {
-				r.recordEventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, "configmap %s/%s not found", ironicConf.Namespace, configMapName)
+				r.recordEventf(ironicConf, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, "configmap %s/%s not found", ironicConf.Namespace, configMapName)
 			}
 		}
 		return nil, true, wrappedErr
@@ -348,7 +348,7 @@ func (r *IronicReconciler) ensureAPISecret(cctx ironic.ControllerContext, ironic
 			// Considering this a transient error
 			return nil, true, fmt.Errorf("cannot update the new API credentials secret: %w", err)
 		}
-		r.recordEventf(ironicConf, nil, corev1.EventTypeNormal, eventReasonAPISecretCreated, "Created new API credentials secret: %s", apiSecret.Name)
+		r.recordEventf(ironicConf, corev1.EventTypeNormal, eventReasonAPISecretCreated, "Created new API credentials secret: %s", apiSecret.Name)
 
 		requeue = true
 		return apiSecret, requeue, err

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -222,19 +222,23 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 		return requeue, err
 	}
 
+	return r.updateIronicStatus(cctx, ironicConf, status, actuallyRequestedVersion)
+}
+
+func (r *IronicReconciler) updateIronicStatus(cctx ironic.ControllerContext, ironicConf *metal3api.Ironic, status ironic.Status, requestedVersion string) (bool, error) {
 	newStatus := ironicConf.Status.DeepCopy()
 	oldReady := isStatusReady(&ironicConf.Status)
 	setConditionsFromStatus(cctx, status, &newStatus.Conditions, ironicConf.Generation, "ironic")
-	requeue = status.NeedsRequeue()
+	requeue := status.NeedsRequeue()
 	if status.IsReady() {
-		newStatus.InstalledVersion = actuallyRequestedVersion
+		newStatus.InstalledVersion = requestedVersion
 	}
 	newReady := isStatusReady(newStatus)
 
 	if !apiequality.Semantic.DeepEqual(newStatus, &ironicConf.Status) {
 		cctx.Logger.Info("updating status", "Status", newStatus)
 		ironicConf.Status = *newStatus
-		err = cctx.Client.Status().Update(cctx.Context, ironicConf)
+		err := cctx.Client.Status().Update(cctx.Context, ironicConf)
 		if err == nil {
 			if newReady && !oldReady {
 				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, "IronicReady", "IronicReady", "Ironic deployment is now ready")
@@ -247,8 +251,9 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, "IronicNotReady", "IronicNotReady", "%s", msg)
 			}
 		}
+		return requeue, err
 	}
-	return requeue, err
+	return requeue, nil
 }
 
 // Get a secret and update its owner references using SecretManager.

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -89,13 +90,9 @@ func (r *IronicReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
-	// Record event for reconciliation start
-	r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "Reconciling", "Starting reconciliation")
-
 	changed, err := r.handleIronic(cctx, ironicConf)
 	if err != nil {
 		cctx.Logger.Error(err, "reconcile failed, will retry")
-		r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "ReconcileFailed", fmt.Sprintf("Reconciliation failed: %v", err))
 		return ctrl.Result{}, err
 	}
 	if changed {
@@ -103,7 +100,6 @@ func (r *IronicReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	logger.Info("object has been fully reconciled")
-	r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "Reconciled", "Object has been fully reconciled")
 	return ctrl.Result{}, nil
 }
 
@@ -167,9 +163,6 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 
 	apiSecret, requeue, err := r.ensureAPISecret(cctx, ironicConf)
 	if requeue || err != nil {
-		if err != nil {
-			r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "APISecretError", fmt.Sprintf("Failed to ensure API secret: %v", err))
-		}
 		return requeue, err
 	}
 
@@ -226,7 +219,6 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 	status, err := ironic.EnsureIronic(cctx, resources)
 	if err != nil {
 		cctx.Logger.Error(err, "potentially transient error, will retry")
-		r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "EnsureIronicFailed", fmt.Sprintf("Failed to ensure Ironic resources: %v", err))
 		return requeue, err
 	}
 
@@ -244,15 +236,15 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 		ironicConf.Status = *newStatus
 		err = cctx.Client.Status().Update(cctx.Context, ironicConf)
 		if err == nil {
-			// Record events for status changes
 			if newReady && !oldReady {
 				r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "IronicReady", "Ironic deployment is now ready")
 			} else if !newReady && oldReady {
-				r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "IronicNotReady", status.String())
-			} else if status.IsError() {
-				r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "IronicError", status.String())
-			} else if !status.IsReady() {
-				r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "IronicInProgress", status.String())
+				readyCond := meta.FindStatusCondition(newStatus.Conditions, string(metal3api.IronicStatusReady))
+				msg := status.String()
+				if readyCond != nil {
+					msg = readyCond.Message
+				}
+				r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "IronicNotReady", msg)
 			}
 		}
 	}

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,7 +52,7 @@ type IronicReconciler struct {
 	Log           logr.Logger
 	Domain        string
 	VersionInfo   ironic.VersionInfo
-	EventRecorder record.EventRecorder
+	EventRecorder events.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=ironic.metal3.io,resources=ironics,verbs=get;list;watch;create;update;patch;delete
@@ -128,7 +128,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 	if err != nil {
 		// This condition requires a user's intervention
 		_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, err.Error())
-		r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "VersionError", fmt.Sprintf("Failed to process version: %v", err))
+		r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, "VersionError", "VersionError", "Failed to process version: %v", err)
 		return true, err
 	}
 	cctx.VersionInfo = versionInfo
@@ -148,7 +148,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 			if !parsedVersion.IsLatest() && cctx.VersionInfo.InstalledVersion.Compare(parsedVersion) < 0 {
 				cctx.Logger.Info("refusing to downgrade Ironic", "InstalledVersion", ironicConf.Status.InstalledVersion, "RequestedVersion", actuallyRequestedVersion)
 				_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, "Ironic does not support downgrades with an external database")
-				r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "DowngradeRejected", fmt.Sprintf("Downgrade from %s to %s is not supported with external database", ironicConf.Status.InstalledVersion, actuallyRequestedVersion))
+				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, "DowngradeRejected", "DowngradeRejected", "Downgrade from %s to %s is not supported with external database", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
 				return false, nil
 			}
 		}
@@ -158,7 +158,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 		if err != nil {
 			return requeue, err
 		}
-		r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "VersionChange", fmt.Sprintf("Version change requested from %s to %s", ironicConf.Status.InstalledVersion, actuallyRequestedVersion))
+		r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, "VersionChange", "VersionChange", "Version change requested from %s to %s", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
 	}
 
 	apiSecret, requeue, err := r.ensureAPISecret(cctx, ironicConf)
@@ -237,14 +237,14 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 		err = cctx.Client.Status().Update(cctx.Context, ironicConf)
 		if err == nil {
 			if newReady && !oldReady {
-				r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "IronicReady", "Ironic deployment is now ready")
+				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, "IronicReady", "IronicReady", "Ironic deployment is now ready")
 			} else if !newReady && oldReady {
 				readyCond := meta.FindStatusCondition(newStatus.Conditions, string(metal3api.IronicStatusReady))
 				msg := status.String()
 				if readyCond != nil {
 					msg = readyCond.Message
 				}
-				r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "IronicNotReady", msg)
+				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, "IronicNotReady", "IronicNotReady", "%s", msg)
 			}
 		}
 	}
@@ -269,7 +269,7 @@ func (r *IronicReconciler) getAndUpdateSecret(cctx ironic.ControllerContext, iro
 			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, wrappedErr.Error())
 		}
 		if k8serrors.IsNotFound(err) {
-			r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "SecretNotFound", fmt.Sprintf("secret %s/%s not found", ironicConf.Namespace, secretName))
+			r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, "SecretNotFound", "SecretNotFound", "secret %s/%s not found", ironicConf.Namespace, secretName)
 		}
 		return nil, true, wrappedErr
 	}
@@ -294,7 +294,7 @@ func (r *IronicReconciler) getConfigMap(cctx ironic.ControllerContext, ironicCon
 			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, wrappedErr.Error())
 		}
 		if k8serrors.IsNotFound(err) {
-			r.EventRecorder.Event(ironicConf, corev1.EventTypeWarning, "ConfigMapNotFound", fmt.Sprintf("configmap %s/%s not found", ironicConf.Namespace, configMapName))
+			r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, "ConfigMapNotFound", "ConfigMapNotFound", "configmap %s/%s not found", ironicConf.Namespace, configMapName)
 		}
 		return nil, true, wrappedErr
 	}
@@ -317,7 +317,7 @@ func (r *IronicReconciler) ensureAPISecret(cctx ironic.ControllerContext, ironic
 			// Considering this a transient error
 			return nil, true, fmt.Errorf("cannot update the new API credentials secret: %w", err)
 		}
-		r.EventRecorder.Event(ironicConf, corev1.EventTypeNormal, "APISecretCreated", fmt.Sprintf("Created new API credentials secret: %s", apiSecret.Name))
+		r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, "APISecretCreated", "APISecretCreated", "Created new API credentials secret: %s", apiSecret.Name)
 
 		requeue = true
 		return apiSecret, requeue, err

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -55,6 +55,18 @@ type IronicReconciler struct {
 	EventRecorder events.EventRecorder
 }
 
+const (
+	eventReasonVersionError      = "VersionError"
+	eventReasonDowngradeRejected = "DowngradeRejected"
+	eventReasonVersionChange     = "VersionChange"
+	eventReasonIronicReady       = "IronicReady"
+	eventReasonIronicNotReady    = "IronicNotReady"
+	eventReasonInvalidLinkedRes  = "InvalidLinkedResource"
+	eventReasonSecretNotFound    = "SecretNotFound"
+	eventReasonConfigMapNotFound = "ConfigMapNotFound"
+	eventReasonAPISecretCreated  = "APISecretCreated"
+)
+
 //+kubebuilder:rbac:groups=ironic.metal3.io,resources=ironics,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ironic.metal3.io,resources=ironics/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=ironic.metal3.io,resources=ironics/finalizers,verbs=update
@@ -128,7 +140,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 	if err != nil {
 		// This condition requires a user's intervention
 		_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, err.Error())
-		r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, "VersionError", "VersionError", "Failed to process version: %v", err)
+		r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonVersionError, eventReasonVersionError, "Failed to process version: %v", err)
 		return true, err
 	}
 	cctx.VersionInfo = versionInfo
@@ -148,7 +160,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 			if !parsedVersion.IsLatest() && cctx.VersionInfo.InstalledVersion.Compare(parsedVersion) < 0 {
 				cctx.Logger.Info("refusing to downgrade Ironic", "InstalledVersion", ironicConf.Status.InstalledVersion, "RequestedVersion", actuallyRequestedVersion)
 				_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, "Ironic does not support downgrades with an external database")
-				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, "DowngradeRejected", "DowngradeRejected", "Downgrade from %s to %s is not supported with external database", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
+				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonDowngradeRejected, eventReasonDowngradeRejected, "Downgrade from %s to %s is not supported with external database", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
 				return false, nil
 			}
 		}
@@ -158,7 +170,7 @@ func (r *IronicReconciler) handleIronic(cctx ironic.ControllerContext, ironicCon
 		if err != nil {
 			return requeue, err
 		}
-		r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, "VersionChange", "VersionChange", "Version change requested from %s to %s", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
+		r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, eventReasonVersionChange, eventReasonVersionChange, "Version change requested from %s to %s", ironicConf.Status.InstalledVersion, actuallyRequestedVersion)
 	}
 
 	apiSecret, requeue, err := r.ensureAPISecret(cctx, ironicConf)
@@ -241,14 +253,14 @@ func (r *IronicReconciler) updateIronicStatus(cctx ironic.ControllerContext, iro
 		err := cctx.Client.Status().Update(cctx.Context, ironicConf)
 		if err == nil {
 			if newReady && !oldReady {
-				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, "IronicReady", "IronicReady", "Ironic deployment is now ready")
+				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, eventReasonIronicReady, eventReasonIronicReady, "Ironic deployment is now ready")
 			} else if !newReady && oldReady {
 				readyCond := meta.FindStatusCondition(newStatus.Conditions, string(metal3api.IronicStatusReady))
 				msg := status.String()
 				if readyCond != nil {
 					msg = readyCond.Message
 				}
-				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, "IronicNotReady", "IronicNotReady", "%s", msg)
+				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonIronicNotReady, eventReasonIronicNotReady, "%s", msg)
 			}
 		}
 		return requeue, err
@@ -269,12 +281,16 @@ func (r *IronicReconciler) getAndUpdateSecret(cctx ironic.ControllerContext, iro
 	secret, err = secretManager.AcquireSecret(namespacedName, ironicConf, cctx.Scheme)
 	if err != nil {
 		wrappedErr := fmt.Errorf("cannot load secret %s/%s: %w", ironicConf.Namespace, secretName, err)
+		// Only missing-label and NotFound errors require user intervention.
+		// Other errors are transient and should just be retried.
 		var missingLabelErr *secretutils.MissingLabelError
 		if errors.As(err, &missingLabelErr) || k8serrors.IsNotFound(err) {
 			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, wrappedErr.Error())
-		}
-		if k8serrors.IsNotFound(err) {
-			r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, "SecretNotFound", "SecretNotFound", "secret %s/%s not found", ironicConf.Namespace, secretName)
+			if errors.As(err, &missingLabelErr) {
+				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, eventReasonInvalidLinkedRes, "secret %s/%s is invalid: %v", ironicConf.Namespace, secretName, err)
+			} else if k8serrors.IsNotFound(err) {
+				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonSecretNotFound, eventReasonSecretNotFound, "secret %s/%s not found", ironicConf.Namespace, secretName)
+			}
 		}
 		return nil, true, wrappedErr
 	}
@@ -294,12 +310,16 @@ func (r *IronicReconciler) getConfigMap(cctx ironic.ControllerContext, ironicCon
 	configMap, err = secretManager.ObtainConfigMap(namespacedName)
 	if err != nil {
 		wrappedErr := fmt.Errorf("cannot load configmap %s/%s: %w", ironicConf.Namespace, configMapName, err)
+		// Only missing-label and NotFound errors require user intervention.
+		// Other errors are transient and should just be retried.
 		var missingLabelErr *secretutils.MissingLabelError
 		if errors.As(err, &missingLabelErr) || k8serrors.IsNotFound(err) {
 			_ = r.setNotReady(cctx, ironicConf, metal3api.IronicReasonFailed, wrappedErr.Error())
-		}
-		if k8serrors.IsNotFound(err) {
-			r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, "ConfigMapNotFound", "ConfigMapNotFound", "configmap %s/%s not found", ironicConf.Namespace, configMapName)
+			if errors.As(err, &missingLabelErr) {
+				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonInvalidLinkedRes, eventReasonInvalidLinkedRes, "configmap %s/%s is invalid: %v", ironicConf.Namespace, configMapName, err)
+			} else if k8serrors.IsNotFound(err) {
+				r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeWarning, eventReasonConfigMapNotFound, eventReasonConfigMapNotFound, "configmap %s/%s not found", ironicConf.Namespace, configMapName)
+			}
 		}
 		return nil, true, wrappedErr
 	}
@@ -322,7 +342,7 @@ func (r *IronicReconciler) ensureAPISecret(cctx ironic.ControllerContext, ironic
 			// Considering this a transient error
 			return nil, true, fmt.Errorf("cannot update the new API credentials secret: %w", err)
 		}
-		r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, "APISecretCreated", "APISecretCreated", "Created new API credentials secret: %s", apiSecret.Name)
+		r.EventRecorder.Eventf(ironicConf, nil, corev1.EventTypeNormal, eventReasonAPISecretCreated, eventReasonAPISecretCreated, "Created new API credentials secret: %s", apiSecret.Name)
 
 		requeue = true
 		return apiSecret, requeue, err

--- a/internal/controller/ironic_controller_test.go
+++ b/internal/controller/ironic_controller_test.go
@@ -1,6 +1,4 @@
 /*
-Copyright 2023.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -26,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
@@ -60,10 +59,12 @@ func newTestIronic() *metal3api.Ironic {
 	}
 }
 
-func newTestControllerContext(t *testing.T, scheme *runtime.Scheme, r *IronicReconciler) ironic.ControllerContext {
+func newTestControllerContext(t *testing.T, scheme *runtime.Scheme, cl client.Client) ironic.ControllerContext {
+	t.Helper()
+
 	return ironic.ControllerContext{
 		Context: t.Context(),
-		Client:  r.Client,
+		Client:  cl,
 		Scheme:  scheme,
 		Logger:  logr.Discard(),
 	}
@@ -93,7 +94,7 @@ func TestGetAndUpdateSecret_NotFound_EmitsSecretNotFoundEvent(t *testing.T) {
 	ironicObj := newTestIronic()
 
 	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
-	cctx := newTestControllerContext(t, scheme, r)
+	cctx := newTestControllerContext(t, scheme, r.Client)
 
 	_, requeue, err := r.getAndUpdateSecret(cctx, ironicObj, "missing-secret")
 
@@ -125,7 +126,7 @@ func TestGetAndUpdateSecret_Found_NoEvent(t *testing.T) {
 	}
 
 	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, ironicObj), recorder)
-	cctx := newTestControllerContext(t, scheme, r)
+	cctx := newTestControllerContext(t, scheme, r.Client)
 
 	result, requeue, err := r.getAndUpdateSecret(cctx, ironicObj, "existing-secret")
 
@@ -137,7 +138,7 @@ func TestGetAndUpdateSecret_Found_NoEvent(t *testing.T) {
 	assert.Empty(t, evts, "no events should be emitted for a found secret")
 }
 
-func TestGetAndUpdateSecret_MissingLabel_NoSecretNotFoundEvent(t *testing.T) {
+func TestGetAndUpdateSecret_MissingLabel_EmitsInvalidLinkedResourceEvent(t *testing.T) {
 	scheme := newTestScheme()
 	recorder := events.NewFakeRecorder(10)
 	ironicObj := newTestIronic()
@@ -151,7 +152,7 @@ func TestGetAndUpdateSecret_MissingLabel_NoSecretNotFoundEvent(t *testing.T) {
 	}
 
 	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(secret, ironicObj), recorder)
-	cctx := newTestControllerContext(t, scheme, r)
+	cctx := newTestControllerContext(t, scheme, r.Client)
 
 	_, requeue, err := r.getAndUpdateSecret(cctx, ironicObj, "unlabeled-secret")
 
@@ -159,10 +160,14 @@ func TestGetAndUpdateSecret_MissingLabel_NoSecretNotFoundEvent(t *testing.T) {
 	assert.True(t, requeue)
 
 	evts := drainEvents(recorder)
+	assert.NotEmpty(t, evts, "InvalidLinkedResource should be emitted for label errors")
+	foundInvalid := false
 	for _, evt := range evts {
-		assert.NotContains(t, evt, "SecretNotFound",
-			"SecretNotFound must not be emitted for label errors (not a NotFound error)")
+		assert.Contains(t, evt, "InvalidLinkedResource", "invalid linked resource reason must be emitted")
+		foundInvalid = true
+		break
 	}
+	assert.True(t, foundInvalid, "InvalidLinkedResource event should be present")
 }
 
 func TestGetConfigMap_NotFound_EmitsConfigMapNotFoundEvent(t *testing.T) {
@@ -171,7 +176,7 @@ func TestGetConfigMap_NotFound_EmitsConfigMapNotFoundEvent(t *testing.T) {
 	ironicObj := newTestIronic()
 
 	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
-	cctx := newTestControllerContext(t, scheme, r)
+	cctx := newTestControllerContext(t, scheme, r.Client)
 
 	_, requeue, err := r.getConfigMap(cctx, ironicObj, "missing-configmap")
 
@@ -200,7 +205,7 @@ func TestGetConfigMap_Found_NoEvent(t *testing.T) {
 	}
 
 	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap, ironicObj), recorder)
-	cctx := newTestControllerContext(t, scheme, r)
+	cctx := newTestControllerContext(t, scheme, r.Client)
 
 	result, requeue, err := r.getConfigMap(cctx, ironicObj, "existing-cm")
 
@@ -212,7 +217,7 @@ func TestGetConfigMap_Found_NoEvent(t *testing.T) {
 	assert.Empty(t, evts, "no events should be emitted for a found configmap")
 }
 
-func TestGetConfigMap_MissingLabel_NoConfigMapNotFoundEvent(t *testing.T) {
+func TestGetConfigMap_MissingLabel_EmitsInvalidLinkedResourceEvent(t *testing.T) {
 	scheme := newTestScheme()
 	recorder := events.NewFakeRecorder(10)
 	ironicObj := newTestIronic()
@@ -226,7 +231,7 @@ func TestGetConfigMap_MissingLabel_NoConfigMapNotFoundEvent(t *testing.T) {
 	}
 
 	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(configMap, ironicObj), recorder)
-	cctx := newTestControllerContext(t, scheme, r)
+	cctx := newTestControllerContext(t, scheme, r.Client)
 
 	_, requeue, err := r.getConfigMap(cctx, ironicObj, "unlabeled-cm")
 
@@ -234,10 +239,14 @@ func TestGetConfigMap_MissingLabel_NoConfigMapNotFoundEvent(t *testing.T) {
 	assert.True(t, requeue)
 
 	evts := drainEvents(recorder)
+	assert.NotEmpty(t, evts, "InvalidLinkedResource should be emitted for label errors")
+	foundInvalid := false
 	for _, evt := range evts {
-		assert.NotContains(t, evt, "ConfigMapNotFound",
-			"ConfigMapNotFound must not be emitted for label errors (not a NotFound error)")
+		assert.Contains(t, evt, "InvalidLinkedResource", "invalid linked resource reason must be emitted")
+		foundInvalid = true
+		break
 	}
+	assert.True(t, foundInvalid, "InvalidLinkedResource event should be present")
 }
 
 func TestEnsureAPISecret_GeneratesSecret_EmitsAPISecretCreatedEvent(t *testing.T) {
@@ -246,7 +255,7 @@ func TestEnsureAPISecret_GeneratesSecret_EmitsAPISecretCreatedEvent(t *testing.T
 	ironicObj := newTestIronic()
 
 	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
-	cctx := newTestControllerContext(t, scheme, r)
+	cctx := newTestControllerContext(t, scheme, r.Client)
 
 	apiSecret, requeue, err := r.ensureAPISecret(cctx, ironicObj)
 
@@ -267,7 +276,7 @@ func TestUpdateIronicStatus_TransitionToReady_EmitsIronicReadyEvent(t *testing.T
 	ironicObj := newTestIronic()
 
 	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
-	cctx := newTestControllerContext(t, scheme, r)
+	cctx := newTestControllerContext(t, scheme, r.Client)
 
 	readyStatus := ironic.Status{Ready: true}
 	requeue, err := r.updateIronicStatus(cctx, ironicObj, readyStatus, "latest")
@@ -296,7 +305,7 @@ func TestUpdateIronicStatus_TransitionToNotReady_EmitsIronicNotReadyEvent(t *tes
 	}
 
 	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
-	cctx := newTestControllerContext(t, scheme, r)
+	cctx := newTestControllerContext(t, scheme, r.Client)
 
 	notReadyStatus := ironic.Status{Message: "deployment not available yet"}
 	requeue, err := r.updateIronicStatus(cctx, ironicObj, notReadyStatus, "latest")
@@ -325,7 +334,7 @@ func TestUpdateIronicStatus_AlreadyReady_NoEvent(t *testing.T) {
 	ironicObj.Status.InstalledVersion = "latest"
 
 	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
-	cctx := newTestControllerContext(t, scheme, r)
+	cctx := newTestControllerContext(t, scheme, r.Client)
 
 	readyStatus := ironic.Status{Ready: true}
 	requeue, err := r.updateIronicStatus(cctx, ironicObj, readyStatus, "latest")
@@ -352,7 +361,7 @@ func TestUpdateIronicStatus_AlreadyNotReady_NoEvent(t *testing.T) {
 	}
 
 	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
-	cctx := newTestControllerContext(t, scheme, r)
+	cctx := newTestControllerContext(t, scheme, r.Client)
 
 	notReadyStatus := ironic.Status{Message: "deployment not available yet"}
 	requeue, err := r.updateIronicStatus(cctx, ironicObj, notReadyStatus, "latest")
@@ -384,7 +393,7 @@ func TestEnsureAPISecret_ExistingSecret_NoAPISecretCreatedEvent(t *testing.T) {
 	}
 
 	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, ironicObj), recorder)
-	cctx := newTestControllerContext(t, scheme, r)
+	cctx := newTestControllerContext(t, scheme, r.Client)
 
 	result, _, err := r.ensureAPISecret(cctx, ironicObj)
 

--- a/internal/controller/ironic_controller_test.go
+++ b/internal/controller/ironic_controller_test.go
@@ -1,4 +1,6 @@
 /*
+Copyright 2026 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -88,7 +90,7 @@ func drainEvents(recorder *events.FakeRecorder) []string {
 	}
 }
 
-func TestGetAndUpdateSecret_NotFound_EmitsSecretNotFoundEvent(t *testing.T) {
+func TestGetAndUpdateSecret_NotFound_EmitsInvalidLinkedResourceEvent(t *testing.T) {
 	scheme := newTestScheme()
 	recorder := events.NewFakeRecorder(10)
 	ironicObj := newTestIronic()
@@ -104,7 +106,7 @@ func TestGetAndUpdateSecret_NotFound_EmitsSecretNotFoundEvent(t *testing.T) {
 
 	evts := drainEvents(recorder)
 	require.Len(t, evts, 1)
-	assert.Contains(t, evts[0], "SecretNotFound")
+	assert.Contains(t, evts[0], "InvalidLinkedResource")
 	assert.Contains(t, evts[0], "secret test-ns/missing-secret not found")
 }
 
@@ -170,7 +172,7 @@ func TestGetAndUpdateSecret_MissingLabel_EmitsInvalidLinkedResourceEvent(t *test
 	assert.True(t, foundInvalid, "InvalidLinkedResource event should be present")
 }
 
-func TestGetConfigMap_NotFound_EmitsConfigMapNotFoundEvent(t *testing.T) {
+func TestGetConfigMap_NotFound_EmitsInvalidLinkedResourceEvent(t *testing.T) {
 	scheme := newTestScheme()
 	recorder := events.NewFakeRecorder(10)
 	ironicObj := newTestIronic()
@@ -186,7 +188,7 @@ func TestGetConfigMap_NotFound_EmitsConfigMapNotFoundEvent(t *testing.T) {
 
 	evts := drainEvents(recorder)
 	require.Len(t, evts, 1)
-	assert.Contains(t, evts[0], "ConfigMapNotFound")
+	assert.Contains(t, evts[0], "InvalidLinkedResource")
 	assert.Contains(t, evts[0], "configmap test-ns/missing-configmap not found")
 }
 

--- a/internal/controller/ironic_controller_test.go
+++ b/internal/controller/ironic_controller_test.go
@@ -1,0 +1,399 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
+	"github.com/metal3-io/ironic-standalone-operator/pkg/ironic"
+)
+
+func newTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = metal3api.AddToScheme(scheme)
+	return scheme
+}
+
+func newTestReconciler(scheme *runtime.Scheme, fakeClient *fake.ClientBuilder, recorder *events.FakeRecorder) *IronicReconciler {
+	cl := fakeClient.Build()
+	return &IronicReconciler{
+		Client:        cl,
+		APIReader:     cl,
+		Scheme:        scheme,
+		Log:           logr.Discard(),
+		EventRecorder: recorder,
+	}
+}
+
+func newTestIronic() *metal3api.Ironic {
+	return &metal3api.Ironic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ironic",
+			Namespace: "test-ns",
+			UID:       "test-uid-12345",
+		},
+	}
+}
+
+func newTestControllerContext(t *testing.T, scheme *runtime.Scheme, r *IronicReconciler) ironic.ControllerContext {
+	return ironic.ControllerContext{
+		Context: t.Context(),
+		Client:  r.Client,
+		Scheme:  scheme,
+		Logger:  logr.Discard(),
+	}
+}
+
+func environmentLabels() map[string]string {
+	return map[string]string{
+		metal3api.LabelEnvironmentName: metal3api.LabelEnvironmentValue,
+	}
+}
+
+func drainEvents(recorder *events.FakeRecorder) []string {
+	var result []string
+	for {
+		select {
+		case evt := <-recorder.Events:
+			result = append(result, evt)
+		default:
+			return result
+		}
+	}
+}
+
+func TestGetAndUpdateSecret_NotFound_EmitsSecretNotFoundEvent(t *testing.T) {
+	scheme := newTestScheme()
+	recorder := events.NewFakeRecorder(10)
+	ironicObj := newTestIronic()
+
+	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
+	cctx := newTestControllerContext(t, scheme, r)
+
+	_, requeue, err := r.getAndUpdateSecret(cctx, ironicObj, "missing-secret")
+
+	require.Error(t, err)
+	assert.True(t, requeue)
+	assert.Contains(t, err.Error(), "cannot load secret")
+
+	evts := drainEvents(recorder)
+	require.Len(t, evts, 1)
+	assert.Contains(t, evts[0], "SecretNotFound")
+	assert.Contains(t, evts[0], "secret test-ns/missing-secret not found")
+}
+
+func TestGetAndUpdateSecret_Found_NoEvent(t *testing.T) {
+	scheme := newTestScheme()
+	recorder := events.NewFakeRecorder(10)
+	ironicObj := newTestIronic()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-secret",
+			Namespace: "test-ns",
+			Labels:    environmentLabels(),
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("pass"),
+		},
+	}
+
+	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, ironicObj), recorder)
+	cctx := newTestControllerContext(t, scheme, r)
+
+	result, requeue, err := r.getAndUpdateSecret(cctx, ironicObj, "existing-secret")
+
+	require.NoError(t, err)
+	assert.False(t, requeue)
+	assert.Equal(t, "existing-secret", result.Name)
+
+	evts := drainEvents(recorder)
+	assert.Empty(t, evts, "no events should be emitted for a found secret")
+}
+
+func TestGetAndUpdateSecret_MissingLabel_NoSecretNotFoundEvent(t *testing.T) {
+	scheme := newTestScheme()
+	recorder := events.NewFakeRecorder(10)
+	ironicObj := newTestIronic()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unlabeled-secret",
+			Namespace: "test-ns",
+		},
+		Data: map[string][]byte{"data": []byte("value")},
+	}
+
+	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(secret, ironicObj), recorder)
+	cctx := newTestControllerContext(t, scheme, r)
+
+	_, requeue, err := r.getAndUpdateSecret(cctx, ironicObj, "unlabeled-secret")
+
+	require.Error(t, err)
+	assert.True(t, requeue)
+
+	evts := drainEvents(recorder)
+	for _, evt := range evts {
+		assert.NotContains(t, evt, "SecretNotFound",
+			"SecretNotFound must not be emitted for label errors (not a NotFound error)")
+	}
+}
+
+func TestGetConfigMap_NotFound_EmitsConfigMapNotFoundEvent(t *testing.T) {
+	scheme := newTestScheme()
+	recorder := events.NewFakeRecorder(10)
+	ironicObj := newTestIronic()
+
+	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
+	cctx := newTestControllerContext(t, scheme, r)
+
+	_, requeue, err := r.getConfigMap(cctx, ironicObj, "missing-configmap")
+
+	require.Error(t, err)
+	assert.True(t, requeue)
+	assert.Contains(t, err.Error(), "cannot load configmap")
+
+	evts := drainEvents(recorder)
+	require.Len(t, evts, 1)
+	assert.Contains(t, evts[0], "ConfigMapNotFound")
+	assert.Contains(t, evts[0], "configmap test-ns/missing-configmap not found")
+}
+
+func TestGetConfigMap_Found_NoEvent(t *testing.T) {
+	scheme := newTestScheme()
+	recorder := events.NewFakeRecorder(10)
+	ironicObj := newTestIronic()
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-cm",
+			Namespace: "test-ns",
+			Labels:    environmentLabels(),
+		},
+		Data: map[string]string{"ca.crt": "cert-data"},
+	}
+
+	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap, ironicObj), recorder)
+	cctx := newTestControllerContext(t, scheme, r)
+
+	result, requeue, err := r.getConfigMap(cctx, ironicObj, "existing-cm")
+
+	require.NoError(t, err)
+	assert.False(t, requeue)
+	assert.Equal(t, "existing-cm", result.Name)
+
+	evts := drainEvents(recorder)
+	assert.Empty(t, evts, "no events should be emitted for a found configmap")
+}
+
+func TestGetConfigMap_MissingLabel_NoConfigMapNotFoundEvent(t *testing.T) {
+	scheme := newTestScheme()
+	recorder := events.NewFakeRecorder(10)
+	ironicObj := newTestIronic()
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unlabeled-cm",
+			Namespace: "test-ns",
+		},
+		Data: map[string]string{"data": "value"},
+	}
+
+	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(configMap, ironicObj), recorder)
+	cctx := newTestControllerContext(t, scheme, r)
+
+	_, requeue, err := r.getConfigMap(cctx, ironicObj, "unlabeled-cm")
+
+	require.Error(t, err)
+	assert.True(t, requeue)
+
+	evts := drainEvents(recorder)
+	for _, evt := range evts {
+		assert.NotContains(t, evt, "ConfigMapNotFound",
+			"ConfigMapNotFound must not be emitted for label errors (not a NotFound error)")
+	}
+}
+
+func TestEnsureAPISecret_GeneratesSecret_EmitsAPISecretCreatedEvent(t *testing.T) {
+	scheme := newTestScheme()
+	recorder := events.NewFakeRecorder(10)
+	ironicObj := newTestIronic()
+
+	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
+	cctx := newTestControllerContext(t, scheme, r)
+
+	apiSecret, requeue, err := r.ensureAPISecret(cctx, ironicObj)
+
+	require.NoError(t, err)
+	assert.True(t, requeue)
+	assert.NotNil(t, apiSecret)
+	assert.NotEmpty(t, ironicObj.Spec.APICredentialsName)
+
+	evts := drainEvents(recorder)
+	require.Len(t, evts, 1)
+	assert.Contains(t, evts[0], "APISecretCreated")
+	assert.Contains(t, evts[0], "Created new API credentials secret")
+}
+
+func TestUpdateIronicStatus_TransitionToReady_EmitsIronicReadyEvent(t *testing.T) {
+	scheme := newTestScheme()
+	recorder := events.NewFakeRecorder(10)
+	ironicObj := newTestIronic()
+
+	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
+	cctx := newTestControllerContext(t, scheme, r)
+
+	readyStatus := ironic.Status{Ready: true}
+	requeue, err := r.updateIronicStatus(cctx, ironicObj, readyStatus, "latest")
+
+	require.NoError(t, err)
+	assert.False(t, requeue)
+
+	evts := drainEvents(recorder)
+	require.Len(t, evts, 1)
+	assert.Contains(t, evts[0], "IronicReady")
+	assert.Contains(t, evts[0], "Ironic deployment is now ready")
+}
+
+func TestUpdateIronicStatus_TransitionToNotReady_EmitsIronicNotReadyEvent(t *testing.T) {
+	scheme := newTestScheme()
+	recorder := events.NewFakeRecorder(10)
+	ironicObj := newTestIronic()
+	ironicObj.Status.Conditions = []metav1.Condition{
+		{
+			Type:               string(metal3api.IronicStatusReady),
+			Status:             metav1.ConditionTrue,
+			Reason:             metal3api.IronicReasonAvailable,
+			Message:            "ironic: resources are available",
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+
+	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
+	cctx := newTestControllerContext(t, scheme, r)
+
+	notReadyStatus := ironic.Status{Message: "deployment not available yet"}
+	requeue, err := r.updateIronicStatus(cctx, ironicObj, notReadyStatus, "latest")
+
+	require.NoError(t, err)
+	assert.False(t, requeue)
+
+	evts := drainEvents(recorder)
+	require.Len(t, evts, 1)
+	assert.Contains(t, evts[0], "IronicNotReady")
+}
+
+func TestUpdateIronicStatus_AlreadyReady_NoEvent(t *testing.T) {
+	scheme := newTestScheme()
+	recorder := events.NewFakeRecorder(10)
+	ironicObj := newTestIronic()
+	ironicObj.Status.Conditions = []metav1.Condition{
+		{
+			Type:               string(metal3api.IronicStatusReady),
+			Status:             metav1.ConditionTrue,
+			Reason:             metal3api.IronicReasonAvailable,
+			Message:            "ironic: resources are available",
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+	ironicObj.Status.InstalledVersion = "latest"
+
+	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
+	cctx := newTestControllerContext(t, scheme, r)
+
+	readyStatus := ironic.Status{Ready: true}
+	requeue, err := r.updateIronicStatus(cctx, ironicObj, readyStatus, "latest")
+
+	require.NoError(t, err)
+	assert.False(t, requeue)
+
+	evts := drainEvents(recorder)
+	assert.Empty(t, evts, "no events should be emitted when status is already ready")
+}
+
+func TestUpdateIronicStatus_AlreadyNotReady_NoEvent(t *testing.T) {
+	scheme := newTestScheme()
+	recorder := events.NewFakeRecorder(10)
+	ironicObj := newTestIronic()
+	ironicObj.Status.Conditions = []metav1.Condition{
+		{
+			Type:               string(metal3api.IronicStatusReady),
+			Status:             metav1.ConditionFalse,
+			Reason:             metal3api.IronicReasonInProgress,
+			Message:            "ironic: deployment not available yet",
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+
+	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ironicObj).WithObjects(ironicObj), recorder)
+	cctx := newTestControllerContext(t, scheme, r)
+
+	notReadyStatus := ironic.Status{Message: "deployment not available yet"}
+	requeue, err := r.updateIronicStatus(cctx, ironicObj, notReadyStatus, "latest")
+
+	require.NoError(t, err)
+	assert.False(t, requeue)
+
+	evts := drainEvents(recorder)
+	assert.Empty(t, evts, "no events should be emitted when status is already not ready")
+}
+
+func TestEnsureAPISecret_ExistingSecret_NoAPISecretCreatedEvent(t *testing.T) {
+	scheme := newTestScheme()
+	recorder := events.NewFakeRecorder(10)
+	ironicObj := newTestIronic()
+	ironicObj.Spec.APICredentialsName = "existing-api-secret"
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-api-secret",
+			Namespace: "test-ns",
+			Labels:    environmentLabels(),
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("secret"),
+			"htpasswd": []byte("admin:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g="),
+		},
+	}
+
+	r := newTestReconciler(scheme, fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, ironicObj), recorder)
+	cctx := newTestControllerContext(t, scheme, r)
+
+	result, _, err := r.ensureAPISecret(cctx, ironicObj)
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+
+	evts := drainEvents(recorder)
+	for _, evt := range evts {
+		assert.NotContains(t, evt, "APISecretCreated",
+			"APISecretCreated must not be emitted when using an existing secret")
+	}
+}

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -115,6 +115,12 @@ func setConditionsFromStatus(cctx ironic.ControllerContext, status ironic.Status
 	setCondition(conditions, generation, true, metal3api.IronicReasonAvailable, message)
 }
 
+// isStatusReady checks if the Ironic status indicates it's ready by looking at the Ready condition.
+func isStatusReady(status *metal3api.IronicStatus) bool {
+	condition := meta.FindStatusCondition(status.Conditions, string(metal3api.IronicStatusReady))
+	return condition != nil && condition.Status == metav1.ConditionTrue
+}
+
 func clusterHasCRD(mgr ctrl.Manager, obj runtime.Object) (bool, error) {
 	gvk, err := apiutil.GVKForObject(obj, mgr.GetScheme())
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
This PR introduces event creation during the reconciliation of objects. By emitting Kubernetes events at key points in the reconcile loop, it improves observability and makes it easier to debug and understand controller behavior.

These events provide better visibility into state changes, errors, and important actions taken by the controller, helping both developers and users quickly diagnose issues.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #25 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
