### PR TITLE
🌱 Add lint-fix target for auto-fixing linter issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Run these locally before submitting PRs:
 | `make generate` | Regenerate DeepCopy methods |
 | `make manifests` | Regenerate CRDs, RBAC, webhooks, API docs |
 | `make lint` | Go linting via golangci-lint (all modules) |
+| `make lint-fix` | Run golangci-lint auto-fixers (all modules) |
 | `make modules` | Verify go.mod is tidy (all 3 modules) |
 
 **Hack scripts** (auto-containerized, match CI exactly):

--- a/Makefile
+++ b/Makefile
@@ -251,9 +251,13 @@ $(GOLANGCI_LINT): $(LOCALBIN) ## Download golangci-lint locally if necessary. If
 .PHONY: lint
 lint: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) config verify
-	$(GOLANGCI_LINT) run -v ./... --timeout=10m
-	cd api; $(GOLANGCI_LINT) run -v --path-prefix=api ./... --timeout=10m
-	cd test; $(GOLANGCI_LINT) run -v --path-prefix=test ./... --timeout=10m
+	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
+	cd api; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --path-prefix=api ./... --timeout=10m
+	cd test; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --path-prefix=test ./... --timeout=10m
+
+.PHONY: lint-fix
+lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter
+	GOLANGCI_LINT_EXTRA_ARGS=--fix $(MAKE) lint
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactor the lint target to support optional arguments via GOLANGCI_LINT_EXTRA_ARGS, enabling a new lint-fix target that runs golangci-lint with the --fix flag across all modules.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
