### PR TITLE
✨ Add bindAddress configuration for prometheus exporter

### DIFF
--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -380,6 +380,17 @@ type PrometheusExporter struct {
 	// ironic-prometheus-exporter container.
 	Enabled bool `json:"enabled"`
 
+	// BindAddress is the IP address the metrics endpoint listens on.
+	// Defaults to "0.0.0.0" to listen on all interfaces.
+	//
+	// Can be set to a specific IP address (e.g. the provisioning network IP)
+	// to limit exposure to a particular network interface, or to "127.0.0.1"
+	// to restrict access to the local host only (note: this makes
+	// ServiceMonitor-based scraping impossible).
+	// +kubebuilder:default="0.0.0.0"
+	// +optional
+	BindAddress string `json:"bindAddress,omitempty"`
+
 	// SensorCollectionInterval defines how often (in seconds) sensor data
 	// is collected from BMCs using Ironic. Must be at least 60 seconds.
 	// +kubebuilder:default=60

--- a/config/crd/bases/ironic.metal3.io_ironics.yaml
+++ b/config/crd/bases/ironic.metal3.io_ironics.yaml
@@ -3738,6 +3738,17 @@ spec:
                   When enabled, this configures Ironic to collect sensor data and deploys the
                   ironic-prometheus-exporter container.
                 properties:
+                  bindAddress:
+                    default: 0.0.0.0
+                    description: |-
+                      BindAddress is the IP address the metrics endpoint listens on.
+                      Defaults to "0.0.0.0" to listen on all interfaces.
+
+                      Can be set to a specific IP address (e.g. the provisioning network IP)
+                      to limit exposure to a particular network interface, or to "127.0.0.1"
+                      to restrict access to the local host only (note: this makes
+                      ServiceMonitor-based scraping impossible).
+                    type: string
                   disableServiceMonitor:
                     description: |-
                       DisableServiceMonitor controls whether a ServiceMonitor resource is created.

--- a/docs/api.md
+++ b/docs/api.md
@@ -7556,6 +7556,21 @@ ironic-prometheus-exporter container.<br/>
         </td>
         <td>true</td>
       </tr><tr>
+        <td><b>bindAddress</b></td>
+        <td>string</td>
+        <td>
+          BindAddress is the IP address the metrics endpoint listens on.
+Defaults to "0.0.0.0" to listen on all interfaces.
+
+Can be set to a specific IP address (e.g. the provisioning network IP)
+to limit exposure to a particular network interface, or to "127.0.0.1"
+to restrict access to the local host only (note: this makes
+ServiceMonitor-based scraping impossible).<br/>
+          <br/>
+            <i>Default</i>: 0.0.0.0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>disableServiceMonitor</b></td>
         <td>boolean</td>
         <td>

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -32,7 +32,8 @@ const (
 	certsDir  = "/certs"
 	sharedDir = "/shared"
 
-	metricsPort = 9608
+	metricsPort            = 9608
+	defaultMetricsBindAddr = "0.0.0.0"
 
 	knownExistingPath = "/images/ironic-python-agent.kernel"
 
@@ -667,6 +668,13 @@ func newKeepalivedContainer(versionInfo VersionInfo, ironic *metal3api.Ironic) c
 	}
 }
 
+func flaskRunHost(ironic *metal3api.Ironic) string {
+	if ironic.Spec.PrometheusExporter != nil && ironic.Spec.PrometheusExporter.BindAddress != "" {
+		return ironic.Spec.PrometheusExporter.BindAddress
+	}
+	return defaultMetricsBindAddr
+}
+
 func newPrometheusExporterContainer(versionInfo VersionInfo, ironic *metal3api.Ironic, volumeMount corev1.VolumeMount) corev1.Container {
 	port := int32(metricsPort)
 	if ironic.Spec.Networking.PrometheusExporterPort != 0 {
@@ -679,10 +687,11 @@ func newPrometheusExporterContainer(versionInfo VersionInfo, ironic *metal3api.I
 		Command: []string{"/bin/runironic-exporter"},
 		Env: []corev1.EnvVar{
 			{
-				// Bind to localhost to prevent unauthenticated access from the
-				// network when the pod runs with hostNetwork: true.
+				// Bind address for the metrics endpoint. Defaults to "0.0.0.0" (all interfaces).
+				// Can be overridden via spec.prometheusExporter.bindAddress, e.g. to
+				// "127.0.0.1" to restrict access to the local host only.
 				Name:  "FLASK_RUN_HOST",
-				Value: "127.0.0.1",
+				Value: flaskRunHost(ironic),
 			},
 			{
 				Name:  "FLASK_RUN_PORT",

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -679,6 +679,12 @@ func newPrometheusExporterContainer(versionInfo VersionInfo, ironic *metal3api.I
 		Command: []string{"/bin/runironic-exporter"},
 		Env: []corev1.EnvVar{
 			{
+				// Bind to localhost to prevent unauthenticated access from the
+				// network when the pod runs with hostNetwork: true.
+				Name:  "FLASK_RUN_HOST",
+				Value: "127.0.0.1",
+			},
+			{
 				Name:  "FLASK_RUN_PORT",
 				Value: strconv.Itoa(int(port)),
 			},

--- a/pkg/ironic/containers_test.go
+++ b/pkg/ironic/containers_test.go
@@ -511,6 +511,7 @@ func TestPrometheusExporterEnvVars(t *testing.T) {
 		prometheusExporter     *metal3api.PrometheusExporter
 		expectedSendSensorData string
 		expectedSensorInterval string
+		expectedFlaskRunHost   string
 	}{
 		{
 			name: "PrometheusExporter enabled with default interval",
@@ -520,6 +521,7 @@ func TestPrometheusExporterEnvVars(t *testing.T) {
 			},
 			expectedSendSensorData: "true",
 			expectedSensorInterval: "60",
+			expectedFlaskRunHost:   "0.0.0.0",
 		},
 		{
 			name: "PrometheusExporter enabled with custom interval",
@@ -529,6 +531,36 @@ func TestPrometheusExporterEnvVars(t *testing.T) {
 			},
 			expectedSendSensorData: "true",
 			expectedSensorInterval: "120",
+			expectedFlaskRunHost:   "0.0.0.0",
+		},
+		{
+			name: "PrometheusExporter enabled with bindAddress 0.0.0.0",
+			prometheusExporter: &metal3api.PrometheusExporter{
+				Enabled:     true,
+				BindAddress: "0.0.0.0",
+			},
+			expectedSendSensorData: "true",
+			expectedSensorInterval: "60",
+			expectedFlaskRunHost:   "0.0.0.0",
+		},
+		{
+			name: "PrometheusExporter enabled with custom bindAddress",
+			prometheusExporter: &metal3api.PrometheusExporter{
+				Enabled:     true,
+				BindAddress: "192.168.1.10",
+			},
+			expectedSendSensorData: "true",
+			expectedSensorInterval: "60",
+			expectedFlaskRunHost:   "192.168.1.10",
+		},
+		{
+			name: "PrometheusExporter enabled with empty bindAddress defaults to wildcard",
+			prometheusExporter: &metal3api.PrometheusExporter{
+				Enabled: true,
+			},
+			expectedSendSensorData: "true",
+			expectedSensorInterval: "60",
+			expectedFlaskRunHost:   "0.0.0.0",
 		},
 		{
 			name: "PrometheusExporter disabled",
@@ -582,7 +614,7 @@ func TestPrometheusExporterEnvVars(t *testing.T) {
 				require.NotNil(t, exporterContainer, "ironic-prometheus-exporter container not found")
 				assert.Len(t, exporterContainer.Env, 2)
 				assert.Equal(t, "FLASK_RUN_HOST", exporterContainer.Env[0].Name)
-				assert.Equal(t, "127.0.0.1", exporterContainer.Env[0].Value)
+				assert.Equal(t, tc.expectedFlaskRunHost, exporterContainer.Env[0].Value)
 				assert.Equal(t, "FLASK_RUN_PORT", exporterContainer.Env[1].Name)
 				assert.Equal(t, "9608", exporterContainer.Env[1].Value)
 				assert.Len(t, exporterContainer.Ports, 1)

--- a/pkg/ironic/containers_test.go
+++ b/pkg/ironic/containers_test.go
@@ -580,9 +580,11 @@ func TestPrometheusExporterEnvVars(t *testing.T) {
 			require.NotNil(t, ironicContainer, "ironic container not found")
 			if expectExporter {
 				require.NotNil(t, exporterContainer, "ironic-prometheus-exporter container not found")
-				assert.Len(t, exporterContainer.Env, 1)
-				assert.Equal(t, "FLASK_RUN_PORT", exporterContainer.Env[0].Name)
-				assert.Equal(t, "9608", exporterContainer.Env[0].Value)
+				assert.Len(t, exporterContainer.Env, 2)
+				assert.Equal(t, "FLASK_RUN_HOST", exporterContainer.Env[0].Name)
+				assert.Equal(t, "127.0.0.1", exporterContainer.Env[0].Value)
+				assert.Equal(t, "FLASK_RUN_PORT", exporterContainer.Env[1].Name)
+				assert.Equal(t, "9608", exporterContainer.Env[1].Value)
 				assert.Len(t, exporterContainer.Ports, 1)
 				assert.Equal(t, int32(9608), exporterContainer.Ports[0].ContainerPort)
 			}

--- a/pkg/ironic/servicemonitor.go
+++ b/pkg/ironic/servicemonitor.go
@@ -41,6 +41,10 @@ func ensureServiceMonitor(cctx ControllerContext, ironic *metal3api.Ironic) (Sta
 			{
 				Port: metricsPortName,
 				// TODO(dtantsur): TLS support?
+				// NOTE: The ironic-prometheus-exporter binds to localhost (127.0.0.1) by default
+				// to prevent unauthenticated access from the host network. This means that
+				// ServiceMonitor-based scraping from a remote Prometheus instance will NOT work
+				// unless the exporter is explicitly configured to listen on all interfaces.
 				Scheme: ptr.To(monitoringv1.SchemeHTTP),
 				Path:   "/metrics",
 			},

--- a/pkg/ironic/servicemonitor.go
+++ b/pkg/ironic/servicemonitor.go
@@ -41,10 +41,6 @@ func ensureServiceMonitor(cctx ControllerContext, ironic *metal3api.Ironic) (Sta
 			{
 				Port: metricsPortName,
 				// TODO(dtantsur): TLS support?
-				// NOTE: The ironic-prometheus-exporter binds to localhost (127.0.0.1) by default
-				// to prevent unauthenticated access from the host network. This means that
-				// ServiceMonitor-based scraping from a remote Prometheus instance will NOT work
-				// unless the exporter is explicitly configured to listen on all interfaces.
 				Scheme: ptr.To(monitoringv1.SchemeHTTP),
 				Path:   "/metrics",
 			},

--- a/pkg/ironic/validation.go
+++ b/pkg/ironic/validation.go
@@ -3,6 +3,7 @@ package ironic
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/netip"
 	"net/url"
 	"reflect"
@@ -213,6 +214,24 @@ func ValidateIronic(ironic *metal3api.IronicSpec, old *metal3api.IronicSpec) err
 
 	if ironic.HighAvailability && ironic.PrometheusExporter != nil && !ironic.PrometheusExporter.DisableServiceMonitor {
 		return errors.New("ServiceMonitor support is currently incompatible with the highly available architecture")
+	}
+
+	if ironic.PrometheusExporter != nil && ironic.PrometheusExporter.BindAddress != "" {
+		ip := net.ParseIP(ironic.PrometheusExporter.BindAddress)
+		if ip == nil {
+			return fmt.Errorf("prometheusExporter: bindAddress %q is not a valid IP address", ironic.PrometheusExporter.BindAddress)
+		}
+	}
+
+	if ironic.PrometheusExporter != nil && ironic.PrometheusExporter.Enabled && !ironic.PrometheusExporter.DisableServiceMonitor {
+		bindAddr := ironic.PrometheusExporter.BindAddress
+		if bindAddr == "" {
+			bindAddr = defaultMetricsBindAddr
+		}
+		ip := net.ParseIP(bindAddr)
+		if ip != nil && ip.IsLoopback() {
+			return fmt.Errorf("ServiceMonitor is not compatible with a loopback bindAddress %q, since the metrics endpoint is not reachable from remote Prometheus instances; set a non-loopback bindAddress or set disableServiceMonitor to true", bindAddr)
+		}
 	}
 
 	if ironic.HighAvailability && !metal3api.CurrentFeatureGate.Enabled(metal3api.FeatureHighAvailability) {

--- a/pkg/ironic/validation_test.go
+++ b/pkg/ironic/validation_test.go
@@ -339,10 +339,114 @@ func TestValidateIronic(t *testing.T) {
 				},
 				HighAvailability: true,
 				PrometheusExporter: &metal3api.PrometheusExporter{
-					Enabled: true,
+					Enabled:     true,
+					BindAddress: "0.0.0.0",
 				},
 			},
 			ExpectedError: "ServiceMonitor support is currently incompatible with the highly available architecture",
+		},
+		{
+			// With the default bindAddress of "0.0.0.0", ServiceMonitor must be valid.
+			Scenario: "ServiceMonitor with default bindAddress is valid",
+			Ironic: metal3api.IronicSpec{
+				PrometheusExporter: &metal3api.PrometheusExporter{
+					Enabled: true,
+				},
+			},
+		},
+		{
+			Scenario: "ServiceMonitor incompatible with explicit loopback bindAddress",
+			Ironic: metal3api.IronicSpec{
+				PrometheusExporter: &metal3api.PrometheusExporter{
+					Enabled:     true,
+					BindAddress: "127.0.0.1",
+				},
+			},
+			ExpectedError: "ServiceMonitor is not compatible with a loopback bindAddress",
+		},
+		{
+			Scenario: "ServiceMonitor incompatible with IPv6 loopback bindAddress",
+			Ironic: metal3api.IronicSpec{
+				PrometheusExporter: &metal3api.PrometheusExporter{
+					Enabled:     true,
+					BindAddress: "::1",
+				},
+			},
+			ExpectedError: "ServiceMonitor is not compatible with a loopback bindAddress",
+		},
+		{
+			Scenario: "ServiceMonitor with bindAddress 0.0.0.0 is valid",
+			Ironic: metal3api.IronicSpec{
+				PrometheusExporter: &metal3api.PrometheusExporter{
+					Enabled:     true,
+					BindAddress: "0.0.0.0",
+				},
+			},
+		},
+		{
+			Scenario: "ServiceMonitor with specific IP bindAddress is valid",
+			Ironic: metal3api.IronicSpec{
+				PrometheusExporter: &metal3api.PrometheusExporter{
+					Enabled:     true,
+					BindAddress: "192.168.1.10",
+				},
+			},
+		},
+		{
+			// disableServiceMonitor must allow a loopback bindAddress that would otherwise
+			// be rejected when ServiceMonitor creation is enabled.
+			Scenario: "disableServiceMonitor bypasses loopback bindAddress requirement",
+			Ironic: metal3api.IronicSpec{
+				PrometheusExporter: &metal3api.PrometheusExporter{
+					Enabled:               true,
+					DisableServiceMonitor: true,
+					BindAddress:           "127.0.0.1",
+				},
+			},
+		},
+		{
+			// Disabled exporter with default (loopback) bindAddress must pass validation
+			// even though DisableServiceMonitor defaults to false. The loopback restriction
+			// only applies when the exporter is actually enabled.
+			Scenario: "disabled exporter with default bindAddress passes validation",
+			Ironic: metal3api.IronicSpec{
+				PrometheusExporter: &metal3api.PrometheusExporter{
+					Enabled: false,
+				},
+			},
+		},
+		{
+			// Disabled exporter with explicit loopback bindAddress must also pass.
+			Scenario: "disabled exporter with loopback bindAddress passes validation",
+			Ironic: metal3api.IronicSpec{
+				PrometheusExporter: &metal3api.PrometheusExporter{
+					Enabled:     false,
+					BindAddress: "127.0.0.1",
+				},
+			},
+		},
+		{
+			// Disabled exporter with ServiceMonitor still enabled (disableServiceMonitor: false)
+			// and a loopback address must not be rejected – the combination is only invalid
+			// when the exporter is running and would actually be scraped.
+			Scenario: "disabled exporter with ServiceMonitor enabled and loopback bindAddress passes validation",
+			Ironic: metal3api.IronicSpec{
+				PrometheusExporter: &metal3api.PrometheusExporter{
+					Enabled:               false,
+					DisableServiceMonitor: false,
+					BindAddress:           "127.0.0.1",
+				},
+			},
+		},
+		{
+			Scenario: "invalid bindAddress",
+			Ironic: metal3api.IronicSpec{
+				PrometheusExporter: &metal3api.PrometheusExporter{
+					Enabled:     true,
+					BindAddress: "not-an-ip",
+				},
+			},
+			ExpectedError: "bindAddress \"not-an-ip\" is not a valid IP address",
 		},
 		{
 			Scenario: "valid agent images single architecture x86_64",

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -467,15 +467,20 @@ func verifyConductorList(ctx context.Context, cli *gophercloud.ServiceClient, as
 }
 
 func verifyPrometheusExporter(ctx context.Context, currentIronicIPs []string) {
-	By("checking ironic-prometheus-exporter")
+	By("checking ironic-prometheus-exporter is not accessible via node IP (localhost binding)")
 
-	httpClient := helpers.NewHTTPClient()
-
-	// NOTE(dtantsur): each Ironic replica has its own exporter, so verify them all independently
+	// The prometheus exporter binds to localhost (127.0.0.1) for security,
+	// so the metrics endpoint must NOT be reachable via the node's external IP.
+	// NOTE(dtantsur): each Ironic replica has its own exporter, so verify them all independently.
 	for _, ironicIP := range currentIronicIPs {
-		testURL := fmt.Sprintf("http://%s/metrics", net.JoinHostPort(ironicIP, "9608"))
-		statusCode := helpers.GetStatusCode(ctx, &httpClient, testURL)
-		Expect(statusCode).To(Equal(200))
+		addr := net.JoinHostPort(ironicIP, "9608")
+		dialer := &net.Dialer{}
+		conn, err := dialer.DialContext(ctx, "tcp", addr)
+		if conn != nil {
+			conn.Close()
+		}
+		Expect(err).To(HaveOccurred(),
+			"metrics endpoint should not be accessible via node IP %s (expected connection refused due to localhost binding)", ironicIP)
 	}
 }
 

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -334,6 +334,9 @@ type TestAssumptions struct {
 
 	// Assume presence of ironic-prometheus-exporter
 	withPrometheusExporter bool
+
+	// The bind address used for the prometheus exporter (empty means default 127.0.0.1)
+	exporterBindAddress string
 }
 
 func verifyAPIVersion(ctx context.Context, cli *gophercloud.ServiceClient, assumptions TestAssumptions) {
@@ -466,21 +469,55 @@ func verifyConductorList(ctx context.Context, cli *gophercloud.ServiceClient, as
 	}
 }
 
-func verifyPrometheusExporter(ctx context.Context, currentIronicIPs []string) {
-	By("checking ironic-prometheus-exporter is not accessible via node IP (localhost binding)")
+func verifyPrometheusExporter(ctx context.Context, currentIronicIPs []string, bindAddress string) {
+	// Resolve empty to the default (0.0.0.0) so the classification below is unambiguous.
+	if bindAddress == "" {
+		bindAddress = "0.0.0.0"
+	}
+	parsedBind := net.ParseIP(bindAddress)
+	isLoopback := parsedBind != nil && parsedBind.IsLoopback()
+	// Wildcard means the exporter is reachable on all interfaces including the node IP.
+	isWildcard := bindAddress == "0.0.0.0" || bindAddress == "::"
 
-	// The prometheus exporter binds to localhost (127.0.0.1) for security,
-	// so the metrics endpoint must NOT be reachable via the node's external IP.
-	// NOTE(dtantsur): each Ironic replica has its own exporter, so verify them all independently.
-	for _, ironicIP := range currentIronicIPs {
-		addr := net.JoinHostPort(ironicIP, "9608")
-		dialer := &net.Dialer{}
-		conn, err := dialer.DialContext(ctx, "tcp", addr)
-		if conn != nil {
-			conn.Close()
+	switch {
+	case isLoopback:
+		By("checking ironic-prometheus-exporter is not accessible via node IP (localhost binding)")
+
+		// The prometheus exporter binds to localhost by default for security, so the
+		// metrics endpoint must NOT be reachable via the node's external IP.
+		// NOTE(dtantsur): each Ironic replica has its own exporter, verify them all independently.
+		for _, ironicIP := range currentIronicIPs {
+			addr := net.JoinHostPort(ironicIP, "9608")
+			dialer := &net.Dialer{}
+			conn, err := dialer.DialContext(ctx, "tcp", addr)
+			if conn != nil {
+				conn.Close()
+			}
+			Expect(err).To(HaveOccurred(),
+				"metrics endpoint should not be accessible via node IP %s (expected connection refused due to localhost binding)", ironicIP)
 		}
-		Expect(err).To(HaveOccurred(),
-			"metrics endpoint should not be accessible via node IP %s (expected connection refused due to localhost binding)", ironicIP)
+
+	case isWildcard:
+		By(fmt.Sprintf("checking ironic-prometheus-exporter is accessible via node IP (bindAddress=%s)", bindAddress))
+
+		httpClient := helpers.NewHTTPClient()
+
+		// NOTE(dtantsur): each Ironic replica has its own exporter, verify them all independently.
+		for _, ironicIP := range currentIronicIPs {
+			testURL := fmt.Sprintf("http://%s/metrics", net.JoinHostPort(ironicIP, "9608"))
+			statusCode := helpers.GetStatusCode(ctx, &httpClient, testURL)
+			Expect(statusCode).To(Equal(200))
+		}
+
+	default:
+		// bindAddress is a specific non-loopback IP (e.g. a provisioning network IP).
+		// Probe that exact address rather than iterating node IPs, which may differ.
+		By("checking ironic-prometheus-exporter is accessible via specific bindAddress " + bindAddress)
+
+		httpClient := helpers.NewHTTPClient()
+		testURL := fmt.Sprintf("http://%s/metrics", net.JoinHostPort(bindAddress, "9608"))
+		statusCode := helpers.GetStatusCode(ctx, &httpClient, testURL)
+		Expect(statusCode).To(Equal(200))
 	}
 }
 
@@ -562,7 +599,7 @@ func VerifyIronic(ironic *metal3api.Ironic, assumptions TestAssumptions) {
 	}
 
 	if assumptions.withPrometheusExporter {
-		verifyPrometheusExporter(withTimeout, currentIronicIPs)
+		verifyPrometheusExporter(withTimeout, currentIronicIPs, assumptions.exporterBindAddress)
 	}
 
 	clients := make([]*gophercloud.ServiceClient, 0, len(ironicURLs))
@@ -1190,8 +1227,9 @@ var _ = Describe("Ironic object tests", func() {
 
 		ironic := helpers.NewIronic(ctx, k8sClient, name, metal3api.IronicSpec{
 			PrometheusExporter: &metal3api.PrometheusExporter{
-				DisableServiceMonitor: os.Getenv("HAS_SERVICE_MONITOR") != "true",
+				DisableServiceMonitor: true,
 				Enabled:               true,
+				BindAddress:           "0.0.0.0",
 			},
 		})
 		DeferCleanup(func() {
@@ -1200,7 +1238,41 @@ var _ = Describe("Ironic object tests", func() {
 		})
 
 		ironic = WaitForIronic(name)
-		VerifyIronic(ironic, TestAssumptions{withPrometheusExporter: true})
+		VerifyIronic(ironic, TestAssumptions{withPrometheusExporter: true, exporterBindAddress: "0.0.0.0"})
+	})
+
+	It("creates Ironic with prometheus exporter bound to specific node IP", Label("prometheus-exporter-specific-ip"), func() {
+		name := types.NamespacedName{
+			Name:      "test-ironic",
+			Namespace: namespace,
+		}
+
+		// ironicIPs[0] is the Kubernetes node InternalIP, populated in BeforeSuite
+		// from the control-plane node list. In a single-node Minikube cluster this
+		// is identical to pod.Status.HostIP, so the exporter can bind to it and
+		// the test runner can reach it directly.
+		Expect(ironicIPs).NotTo(BeEmpty(), "ironicIPs must be populated before this test runs")
+		specificIP := ironicIPs[0]
+		parsedIP := net.ParseIP(specificIP)
+		Expect(parsedIP).NotTo(BeNil(), "ironicIPs[0] must be a valid IP address")
+		Expect(parsedIP.IsLoopback()).To(BeFalse(), "ironicIPs[0] must be a non-loopback address for this test to be meaningful")
+
+		ironic := helpers.NewIronic(ctx, k8sClient, name, metal3api.IronicSpec{
+			PrometheusExporter: &metal3api.PrometheusExporter{
+				DisableServiceMonitor: true,
+				Enabled:               true,
+				// Bind only to the node's specific external IP, not to all interfaces.
+				// verifyPrometheusExporter will probe this address directly.
+				BindAddress: specificIP,
+			},
+		})
+		DeferCleanup(func() {
+			CollectLogs(namespace)
+			DeleteAndWait(ironic)
+		})
+
+		ironic = WaitForIronic(name)
+		VerifyIronic(ironic, TestAssumptions{withPrometheusExporter: true, exporterBindAddress: specificIP})
 	})
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The first commit just makes the exporter bind to localhost for security. The second commit then makes this configurable, with localhost as default.

This adds a new `bindAddress` field to the PrometheusExporter spec,
allowing operators to configure which IP address the metrics endpoint
listens on. It defaults to "0.0.0.0" for backwards compatibility and
convenience but can be set to a specific IP for added security, or even a loopback
address for specialized security configurations.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
