### PR TITLE
🌱  Set IRONIC_CACERT_FILE to trusted CA path when configured

### DIFF
--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -264,7 +264,11 @@ func buildTrustedCAEnvVars(cctx ControllerContext, resources Resources) []corev1
 
 	return []corev1.EnvVar{
 		{
-			Name:  "WEBSERVER_CACERT_FILE",
+			Name:  "WEBSERVER_CACERT_FILE", // CA for verifying image server TLS connections
+			Value: caPath,
+		},
+		{
+			Name:  "IRONIC_CACERT_FILE", // CA for verifying JSON-RPC TLS connections (e.g. ironic-networking)
 			Value: caPath,
 		},
 	}

--- a/pkg/ironic/containers_test.go
+++ b/pkg/ironic/containers_test.go
@@ -326,8 +326,7 @@ func TestTrustedCAConfigMap(t *testing.T) {
 			ExpectVolumeMount:       true,
 			ExpectEnvVar:            true,
 			ExpectedVolumeMountPath: "/certs/ca/trusted",
-			// Note: The actual key used will depend on map iteration order, but we just verify it exists
-			ExpectedEnvVarValue: "", // We'll check it contains /certs/ca/trusted/ prefix instead
+			ExpectedEnvVarValue:     "/certs/ca/trusted/ca-bundle.crt", // keys are sorted, ca-bundle.crt comes first
 		},
 		{
 			Scenario:           "without TrustedCAConfigMap",
@@ -400,24 +399,31 @@ func TestTrustedCAConfigMap(t *testing.T) {
 			}
 			assert.Equal(t, tc.ExpectVolumeMount, foundMount, "Volume mount existence mismatch")
 
-			// Check environment variable (WEBSERVER_CACERT_FILE)
-			var foundWebserverCACert bool
-			var webserverCACertValue string
+			// Check environment variables (WEBSERVER_CACERT_FILE and IRONIC_CACERT_FILE)
+			var foundWebserverCACert, foundIronicCACert bool
+			var webserverCACertValue, ironicCACertValue string
 			for _, env := range ironicContainer.Env {
 				if env.Name == "WEBSERVER_CACERT_FILE" {
 					foundWebserverCACert = true
 					webserverCACertValue = env.Value
 				}
+				if env.Name == "IRONIC_CACERT_FILE" {
+					foundIronicCACert = true
+					ironicCACertValue = env.Value
+				}
 			}
 			assert.Equal(t, tc.ExpectEnvVar, foundWebserverCACert, "WEBSERVER_CACERT_FILE environment variable existence mismatch")
+			assert.Equal(t, tc.ExpectEnvVar, foundIronicCACert, "IRONIC_CACERT_FILE environment variable existence mismatch")
 
 			if tc.ExpectEnvVar {
 				if tc.ExpectedEnvVarValue != "" {
 					// Exact match for single key case
 					assert.Equal(t, tc.ExpectedEnvVarValue, webserverCACertValue, "WEBSERVER_CACERT_FILE value mismatch")
+					assert.Equal(t, tc.ExpectedEnvVarValue, ironicCACertValue, "IRONIC_CACERT_FILE value mismatch")
 				} else {
 					// For multiple keys case, just verify it starts with the correct prefix
-					assert.Contains(t, webserverCACertValue, "/certs/ca/trusted/", "WEBSERVER_CACERT_FILE should contain /certs/ca/trusted/")
+					assert.True(t, strings.HasPrefix(webserverCACertValue, "/certs/ca/trusted/"), "WEBSERVER_CACERT_FILE should start with /certs/ca/trusted/")
+					assert.True(t, strings.HasPrefix(ironicCACertValue, "/certs/ca/trusted/"), "IRONIC_CACERT_FILE should start with /certs/ca/trusted/")
 				}
 			}
 		})
@@ -1014,13 +1020,15 @@ func TestBuildTrustedCAEnvVars(t *testing.T) {
 
 			envVars := buildTrustedCAEnvVars(cctx, resources)
 
-			// Should always return exactly one env var
-			require.Len(t, envVars, 1, "Should return exactly one environment variable")
+			// Should return WEBSERVER_CACERT_FILE and IRONIC_CACERT_FILE
+			require.Len(t, envVars, 2, "Should return two environment variables")
 			assert.Equal(t, "WEBSERVER_CACERT_FILE", envVars[0].Name)
+			assert.Equal(t, "IRONIC_CACERT_FILE", envVars[1].Name)
 
 			// Verify the path contains the expected key
 			expectedPath := "/certs/ca/trusted/" + tc.expectedKey
-			assert.Equal(t, expectedPath, envVars[0].Value, "Environment variable value mismatch")
+			assert.Equal(t, expectedPath, envVars[0].Value, "WEBSERVER_CACERT_FILE value mismatch")
+			assert.Equal(t, expectedPath, envVars[1].Value, "IRONIC_CACERT_FILE value mismatch")
 		})
 	}
 }
@@ -1090,10 +1098,13 @@ func TestBuildTrustedCAEnvVarsKeySelection(t *testing.T) {
 			}
 
 			envVars := buildTrustedCAEnvVars(cctx, resources)
-			require.Len(t, envVars, 1)
+			require.Len(t, envVars, 2)
 
 			expectedPath := "/certs/ca/trusted/" + tc.expectedKey
+			assert.Equal(t, "WEBSERVER_CACERT_FILE", envVars[0].Name)
 			assert.Equal(t, expectedPath, envVars[0].Value)
+			assert.Equal(t, "IRONIC_CACERT_FILE", envVars[1].Name)
+			assert.Equal(t, expectedPath, envVars[1].Value)
 		})
 	}
 }

--- a/pkg/ironic/containers_test.go
+++ b/pkg/ironic/containers_test.go
@@ -287,9 +287,6 @@ func TestTrustedCAConfigMap(t *testing.T) {
 	testCases := []struct {
 		Scenario                string
 		TrustedCAConfigMap      *corev1.ConfigMap
-		ExpectVolume            bool
-		ExpectVolumeMount       bool
-		ExpectEnvVar            bool
 		ExpectedVolumeMountPath string
 		ExpectedEnvVarValue     string
 	}{
@@ -304,9 +301,6 @@ func TestTrustedCAConfigMap(t *testing.T) {
 					"ca-bundle.crt": "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
 				},
 			},
-			ExpectVolume:            true,
-			ExpectVolumeMount:       true,
-			ExpectEnvVar:            true,
 			ExpectedVolumeMountPath: "/certs/ca/trusted",
 			ExpectedEnvVarValue:     "/certs/ca/trusted/ca-bundle.crt",
 		},
@@ -322,18 +316,12 @@ func TestTrustedCAConfigMap(t *testing.T) {
 					"extra-ca.crt":  "-----BEGIN CERTIFICATE-----\nextra\n-----END CERTIFICATE-----",
 				},
 			},
-			ExpectVolume:            true,
-			ExpectVolumeMount:       true,
-			ExpectEnvVar:            true,
 			ExpectedVolumeMountPath: "/certs/ca/trusted",
 			ExpectedEnvVarValue:     "/certs/ca/trusted/ca-bundle.crt", // keys are sorted, ca-bundle.crt comes first
 		},
 		{
 			Scenario:           "without TrustedCAConfigMap",
 			TrustedCAConfigMap: nil,
-			ExpectVolume:       false,
-			ExpectVolumeMount:  false,
-			ExpectEnvVar:       false,
 		},
 	}
 
@@ -362,19 +350,21 @@ func TestTrustedCAConfigMap(t *testing.T) {
 			podTemplate, err := newIronicPodTemplate(cctx, resources)
 			require.NoError(t, err)
 
+			expectTrustedCA := tc.ExpectedEnvVarValue != ""
+
 			// Check volume
 			var foundVolume bool
 			for _, vol := range podTemplate.Spec.Volumes {
 				if vol.Name == "trusted-ca" {
 					foundVolume = true
-					if tc.ExpectVolume {
+					if expectTrustedCA {
 						assert.NotNil(t, vol.ConfigMap)
 						assert.Equal(t, tc.TrustedCAConfigMap.Name, vol.ConfigMap.Name)
 					}
 					break
 				}
 			}
-			assert.Equal(t, tc.ExpectVolume, foundVolume, "Volume existence mismatch")
+			assert.Equal(t, expectTrustedCA, foundVolume, "Volume existence mismatch")
 
 			// Check volume mount on ironic container
 			var ironicContainer *corev1.Container
@@ -390,14 +380,14 @@ func TestTrustedCAConfigMap(t *testing.T) {
 			for _, mount := range ironicContainer.VolumeMounts {
 				if mount.Name == "trusted-ca" {
 					foundMount = true
-					if tc.ExpectVolumeMount {
+					if expectTrustedCA {
 						assert.Equal(t, tc.ExpectedVolumeMountPath, mount.MountPath)
 						assert.True(t, mount.ReadOnly)
 					}
 					break
 				}
 			}
-			assert.Equal(t, tc.ExpectVolumeMount, foundMount, "Volume mount existence mismatch")
+			assert.Equal(t, expectTrustedCA, foundMount, "Volume mount existence mismatch")
 
 			// Check environment variables (WEBSERVER_CACERT_FILE and IRONIC_CACERT_FILE)
 			var foundWebserverCACert, foundIronicCACert bool
@@ -412,19 +402,12 @@ func TestTrustedCAConfigMap(t *testing.T) {
 					ironicCACertValue = env.Value
 				}
 			}
-			assert.Equal(t, tc.ExpectEnvVar, foundWebserverCACert, "WEBSERVER_CACERT_FILE environment variable existence mismatch")
-			assert.Equal(t, tc.ExpectEnvVar, foundIronicCACert, "IRONIC_CACERT_FILE environment variable existence mismatch")
+			assert.Equal(t, expectTrustedCA, foundWebserverCACert, "WEBSERVER_CACERT_FILE environment variable existence mismatch")
+			assert.Equal(t, expectTrustedCA, foundIronicCACert, "IRONIC_CACERT_FILE environment variable existence mismatch")
 
-			if tc.ExpectEnvVar {
-				if tc.ExpectedEnvVarValue != "" {
-					// Exact match for single key case
-					assert.Equal(t, tc.ExpectedEnvVarValue, webserverCACertValue, "WEBSERVER_CACERT_FILE value mismatch")
-					assert.Equal(t, tc.ExpectedEnvVarValue, ironicCACertValue, "IRONIC_CACERT_FILE value mismatch")
-				} else {
-					// For multiple keys case, just verify it starts with the correct prefix
-					assert.True(t, strings.HasPrefix(webserverCACertValue, "/certs/ca/trusted/"), "WEBSERVER_CACERT_FILE should start with /certs/ca/trusted/")
-					assert.True(t, strings.HasPrefix(ironicCACertValue, "/certs/ca/trusted/"), "IRONIC_CACERT_FILE should start with /certs/ca/trusted/")
-				}
+			if expectTrustedCA {
+				assert.Equal(t, tc.ExpectedEnvVarValue, webserverCACertValue, "WEBSERVER_CACERT_FILE value mismatch")
+				assert.Equal(t, tc.ExpectedEnvVarValue, ironicCACertValue, "IRONIC_CACERT_FILE value mismatch")
 			}
 		})
 	}


### PR DESCRIPTION
When a trusted CA is configured via spec.tls.trustedCA or spec.tls.trustedCAName, set IRONIC_CACERT_FILE to the same path as WEBSERVER_CACERT_FILE. This ensures the ironic-image uses the trusted CA bundle for TLS verification of RPC connections instead of falling back to the leaf certificate, which fails when certs are issued by a non-self-signed CA chain.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

I found this while doing testing on PR #566.  The WEBSERVER_CACERT_FILE variable only applies for the image downloading and not the other https type connections used for RPC.  I figured it would be best to split it out into its own PR to avoid cluttering the other larger one.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
