### PR TITLE
🌱 Fix IRSO functional test 

### DIFF
--- a/test/helpers/clients.go
+++ b/test/helpers/clients.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -48,10 +49,18 @@ func NewHTTPClient() http.Client {
 
 func GetStatusCode(ctx context.Context, httpClient *http.Client, url string) int {
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, http.NoBody)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		GinkgoWriter.Printf("Failed to create request for %s: %v\n", url, err)
+		// Return 0 to allow Eventually to retry on errors
+		return 0
+	}
 
 	resp, err := httpClient.Do(req) //nolint:gosec // URL is controlled by test infrastructure
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		GinkgoWriter.Printf("Failed to connect to %s: %v\n", url, err)
+		// Return 0 to allow Eventually to retry on connection errors
+		return 0
+	}
 	defer resp.Body.Close()
 
 	return resp.StatusCode

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -505,8 +505,9 @@ func verifyPrometheusExporter(ctx context.Context, currentIronicIPs []string, bi
 		// NOTE(dtantsur): each Ironic replica has its own exporter, verify them all independently.
 		for _, ironicIP := range currentIronicIPs {
 			testURL := fmt.Sprintf("http://%s/metrics", net.JoinHostPort(ironicIP, "9608"))
-			statusCode := helpers.GetStatusCode(ctx, &httpClient, testURL)
-			Expect(statusCode).To(Equal(200))
+			Eventually(func() int {
+				return helpers.GetStatusCode(ctx, &httpClient, testURL)
+			}, 30*time.Second, 1*time.Second).Should(Equal(200))
 		}
 
 	default:
@@ -516,8 +517,9 @@ func verifyPrometheusExporter(ctx context.Context, currentIronicIPs []string, bi
 
 		httpClient := helpers.NewHTTPClient()
 		testURL := fmt.Sprintf("http://%s/metrics", net.JoinHostPort(bindAddress, "9608"))
-		statusCode := helpers.GetStatusCode(ctx, &httpClient, testURL)
-		Expect(statusCode).To(Equal(200))
+		Eventually(func() int {
+			return helpers.GetStatusCode(ctx, &httpClient, testURL)
+		}, 30*time.Second, 1*time.Second).Should(Equal(200))
 	}
 }
 


### PR DESCRIPTION
The test is checking if the prometheus exporter is accessible, but it's not using a retry mechanism (Eventually) to handle the case where the service might not be immediately ready to accept connections. So this PR will handle the situation by adding eventually to add retry option.