### PR TITLE
🌱 Add readiness probe to ironic-prometheus-exporter

### DIFF
--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net"
 	"net/netip"
 	"os"
 	"slices"
@@ -12,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
@@ -683,7 +685,9 @@ func newPrometheusExporterContainer(versionInfo VersionInfo, ironic *metal3api.I
 		port = ironic.Spec.Networking.PrometheusExporterPort
 	}
 
-	return corev1.Container{
+	bindAddress := flaskRunHost(ironic)
+
+	container := corev1.Container{
 		Name:    "ironic-prometheus-exporter",
 		Image:   versionInfo.IronicImage,
 		Command: []string{"/bin/runironic-exporter"},
@@ -693,7 +697,7 @@ func newPrometheusExporterContainer(versionInfo VersionInfo, ironic *metal3api.I
 				// Can be overridden via spec.prometheusExporter.bindAddress, e.g. to
 				// "127.0.0.1" to restrict access to the local host only.
 				Name:  "FLASK_RUN_HOST",
-				Value: flaskRunHost(ironic),
+				Value: bindAddress,
 			},
 			{
 				Name:  "FLASK_RUN_PORT",
@@ -716,6 +720,42 @@ func newPrometheusExporterContainer(versionInfo VersionInfo, ironic *metal3api.I
 			},
 		},
 	}
+
+	// Add readiness probe, handling different bind address scenarios.
+	// With HostNetwork: true, kubelet probes use PodIP (the node's primary IP),
+	// which may differ from bindAddress when set to a specific interface IP.
+	// We must set HTTPGet.Host to ensure the probe reaches the correct address.
+	parsedIP := net.ParseIP(bindAddress)
+	isLoopback := parsedIP != nil && parsedIP.IsLoopback()
+
+	if !isLoopback {
+		// Determine the host to use in the probe.
+		// For unspecified/wildcard addresses, probe localhost.
+		// For specific IPs, probe that specific address.
+		probeHost := bindAddress
+		isWildcard := parsedIP != nil && parsedIP.IsUnspecified()
+		if isWildcard {
+			probeHost = "127.0.0.1"
+		}
+
+		container.ReadinessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/metrics",
+					Port:   intstr.FromInt32(port),
+					Host:   probeHost,
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      5,
+			SuccessThreshold:    1,
+			FailureThreshold:    3,
+		}
+	}
+
+	return container
 }
 
 func newIronicPodTemplate(cctx ControllerContext, resources Resources) (corev1.PodTemplateSpec, error) {

--- a/pkg/ironic/containers_test.go
+++ b/pkg/ironic/containers_test.go
@@ -499,6 +499,8 @@ func TestPrometheusExporterEnvVars(t *testing.T) {
 		expectedSendSensorData string
 		expectedSensorInterval string
 		expectedFlaskRunHost   string
+		expectReadinessProbe   bool
+		expectedProbeHost      string
 	}{
 		{
 			name: "PrometheusExporter enabled with default interval",
@@ -509,6 +511,8 @@ func TestPrometheusExporterEnvVars(t *testing.T) {
 			expectedSendSensorData: "true",
 			expectedSensorInterval: "60",
 			expectedFlaskRunHost:   "0.0.0.0",
+			expectReadinessProbe:   true,
+			expectedProbeHost:      "127.0.0.1",
 		},
 		{
 			name: "PrometheusExporter enabled with custom interval",
@@ -519,6 +523,8 @@ func TestPrometheusExporterEnvVars(t *testing.T) {
 			expectedSendSensorData: "true",
 			expectedSensorInterval: "120",
 			expectedFlaskRunHost:   "0.0.0.0",
+			expectReadinessProbe:   true,
+			expectedProbeHost:      "127.0.0.1",
 		},
 		{
 			name: "PrometheusExporter enabled with bindAddress 0.0.0.0",
@@ -529,6 +535,20 @@ func TestPrometheusExporterEnvVars(t *testing.T) {
 			expectedSendSensorData: "true",
 			expectedSensorInterval: "60",
 			expectedFlaskRunHost:   "0.0.0.0",
+			expectReadinessProbe:   true,
+			expectedProbeHost:      "127.0.0.1",
+		},
+		{
+			name: "PrometheusExporter enabled with IPv6 wildcard bindAddress ::",
+			prometheusExporter: &metal3api.PrometheusExporter{
+				Enabled:     true,
+				BindAddress: "::",
+			},
+			expectedSendSensorData: "true",
+			expectedSensorInterval: "60",
+			expectedFlaskRunHost:   "::",
+			expectReadinessProbe:   true,
+			expectedProbeHost:      "127.0.0.1",
 		},
 		{
 			name: "PrometheusExporter enabled with custom bindAddress",
@@ -539,6 +559,19 @@ func TestPrometheusExporterEnvVars(t *testing.T) {
 			expectedSendSensorData: "true",
 			expectedSensorInterval: "60",
 			expectedFlaskRunHost:   "192.168.1.10",
+			expectReadinessProbe:   true,
+			expectedProbeHost:      "192.168.1.10", // Specific IP probes itself
+		},
+		{
+			name: "PrometheusExporter enabled with localhost bindAddress",
+			prometheusExporter: &metal3api.PrometheusExporter{
+				Enabled:     true,
+				BindAddress: "127.0.0.1",
+			},
+			expectedSendSensorData: "true",
+			expectedSensorInterval: "60",
+			expectedFlaskRunHost:   "127.0.0.1",
+			expectReadinessProbe:   false, // No HTTP probe for localhost binding
 		},
 		{
 			name: "PrometheusExporter enabled with empty bindAddress defaults to wildcard",
@@ -548,6 +581,8 @@ func TestPrometheusExporterEnvVars(t *testing.T) {
 			expectedSendSensorData: "true",
 			expectedSensorInterval: "60",
 			expectedFlaskRunHost:   "0.0.0.0",
+			expectReadinessProbe:   true,
+			expectedProbeHost:      "127.0.0.1",
 		},
 		{
 			name: "PrometheusExporter disabled",
@@ -606,6 +641,20 @@ func TestPrometheusExporterEnvVars(t *testing.T) {
 				assert.Equal(t, "9608", exporterContainer.Env[1].Value)
 				assert.Len(t, exporterContainer.Ports, 1)
 				assert.Equal(t, int32(9608), exporterContainer.Ports[0].ContainerPort)
+
+				// Verify readiness probe is configured based on bind address
+				if tc.expectReadinessProbe {
+					require.NotNil(t, exporterContainer.ReadinessProbe, "readiness probe should be set for non-localhost binding")
+					require.NotNil(t, exporterContainer.ReadinessProbe.HTTPGet, "HTTPGet probe should be set")
+					assert.Equal(t, "/metrics", exporterContainer.ReadinessProbe.HTTPGet.Path)
+					assert.Equal(t, intstr.FromInt32(9608), exporterContainer.ReadinessProbe.HTTPGet.Port)
+					assert.Equal(t, corev1.URISchemeHTTP, exporterContainer.ReadinessProbe.HTTPGet.Scheme)
+					assert.Equal(t, tc.expectedProbeHost, exporterContainer.ReadinessProbe.HTTPGet.Host)
+					assert.Equal(t, int32(5), exporterContainer.ReadinessProbe.InitialDelaySeconds)
+					assert.Equal(t, int32(10), exporterContainer.ReadinessProbe.PeriodSeconds)
+				} else {
+					assert.Nil(t, exporterContainer.ReadinessProbe, "readiness probe should not be set for localhost binding")
+				}
 			}
 
 			// Check for SEND_SENSOR_DATA env var

--- a/test/helpers/clients.go
+++ b/test/helpers/clients.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -49,18 +48,10 @@ func NewHTTPClient() http.Client {
 
 func GetStatusCode(ctx context.Context, httpClient *http.Client, url string) int {
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, http.NoBody)
-	if err != nil {
-		GinkgoWriter.Printf("Failed to create request for %s: %v\n", url, err)
-		// Return 0 to allow Eventually to retry on errors
-		return 0
-	}
+	Expect(err).NotTo(HaveOccurred())
 
 	resp, err := httpClient.Do(req) //nolint:gosec // URL is controlled by test infrastructure
-	if err != nil {
-		GinkgoWriter.Printf("Failed to connect to %s: %v\n", url, err)
-		// Return 0 to allow Eventually to retry on connection errors
-		return 0
-	}
+	Expect(err).NotTo(HaveOccurred())
 	defer resp.Body.Close()
 
 	return resp.StatusCode

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -505,9 +505,8 @@ func verifyPrometheusExporter(ctx context.Context, currentIronicIPs []string, bi
 		// NOTE(dtantsur): each Ironic replica has its own exporter, verify them all independently.
 		for _, ironicIP := range currentIronicIPs {
 			testURL := fmt.Sprintf("http://%s/metrics", net.JoinHostPort(ironicIP, "9608"))
-			Eventually(func() int {
-				return helpers.GetStatusCode(ctx, &httpClient, testURL)
-			}, 30*time.Second, 1*time.Second).Should(Equal(200))
+			statusCode := helpers.GetStatusCode(ctx, &httpClient, testURL)
+			Expect(statusCode).To(Equal(200))
 		}
 
 	default:
@@ -517,9 +516,8 @@ func verifyPrometheusExporter(ctx context.Context, currentIronicIPs []string, bi
 
 		httpClient := helpers.NewHTTPClient()
 		testURL := fmt.Sprintf("http://%s/metrics", net.JoinHostPort(bindAddress, "9608"))
-		Eventually(func() int {
-			return helpers.GetStatusCode(ctx, &httpClient, testURL)
-		}, 30*time.Second, 1*time.Second).Should(Equal(200))
+		statusCode := helpers.GetStatusCode(ctx, &httpClient, testURL)
+		Expect(statusCode).To(Equal(200))
 	}
 }
 


### PR DESCRIPTION
IRSO functional test had an issue that was having a [workaround](https://github.com/metal3-io/ironic-standalone-operator/pull/651) . It was adding the retry , if the prometheus exporter is accessible. This is a followup fix to have readiness probe in IPE and here we  are adding readiness probe for IPE to avoid  such issue. 