### PR TITLE
🌱 CI: skip the prometheus test with bindAddress on multinode jobs

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -1254,6 +1254,9 @@ var _ = Describe("Ironic object tests", func() {
 		// is identical to pod.Status.HostIP, so the exporter can bind to it and
 		// the test runner can reach it directly.
 		Expect(ironicIPs).NotTo(BeEmpty(), "ironicIPs must be populated before this test runs")
+		if len(ironicIPs) > 1 {
+			Skip("this test relies on a single-node cluster")
+		}
 		specificIP := ironicIPs[0]
 		parsedIP := net.ParseIP(specificIP)
 		Expect(parsedIP).NotTo(BeNil(), "ironicIPs[0] must be a valid IP address")


### PR DESCRIPTION
The test will only succeed in 1 of N cases where N nodes are present.
This is affecting the ironic-image CI where all tests run in a multinode
setup.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
