### PR TITLE
🌱Bump golang version to 1.25.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.25.9@sha256:5ab234a9519e05043f4a97a505a59f21dc40eee172d6b17d411863d6bba599bb
+ARG BUILD_IMAGE=docker.io/golang:1.25.10@sha256:69a7b8cc06cfb629da20d23be8f8f359a1f823481ab1a14b4e1ece153ea1d1c0
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL = /usr/bin/env bash -o pipefail
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.25.9
+GO_VERSION ?= 1.25.10
 GO := $(shell type -P go)
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell $(GO) env GOPROXY)


### PR DESCRIPTION
Bump go to 1.25.10 to fix the following CVEs
https://github.com/advisories/GHSA-497x-jcxf-m478
https://github.com/advisories/GHSA-qc64-m6c2-v4x7
https://github.com/advisories/GHSA-5m4p-2gjx-p2g8
https://github.com/advisories/GHSA-p9h5-jm8x-mjm5
https://github.com/advisories/GHSA-2283-wf8c-rw8r
https://github.com/advisories/GHSA-h74g-238j-357m
https://github.com/advisories/GHSA-3v2c-x6q9-f697
https://github.com/advisories/GHSA-xq5j-9r39-c3vf
https://github.com/advisories/GHSA-qf3q-3h68-mmh2