### PR TITLE
🌱  Skip networking tests when ironic-image is older than 35.0

### DIFF
--- a/test/helpers/resources.go
+++ b/test/helpers/resources.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -37,6 +38,19 @@ func SkipIfCustomImage() {
 	GinkgoHelper()
 	if UsesCustomImage() {
 		Skip("skipping because a custom image is provided")
+	}
+}
+
+func SkipIfVersionBefore(minVersion string) {
+	GinkgoHelper()
+	if CustomImageVersion == "" || CustomImageVersion == "latest" {
+		return
+	}
+	custom, err := metal3api.ParseVersion(CustomImageVersion)
+	Expect(err).NotTo(HaveOccurred(), "invalid IRONIC_CUSTOM_VERSION %q", CustomImageVersion)
+	minimum := metal3api.MustParseVersion(minVersion)
+	if custom.Compare(minimum) < 0 {
+		Skip(fmt.Sprintf("skipping because custom image version %s is before %s", CustomImageVersion, minVersion))
 	}
 }
 

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -1279,6 +1279,8 @@ var _ = Describe("Ironic object tests", func() {
 	})
 
 	It("creates Ironic with networking service", Label("networking"), func() {
+		helpers.SkipIfVersionBefore("35.0")
+
 		name := types.NamespacedName{
 			Name:      "test-ironic",
 			Namespace: namespace,
@@ -1305,6 +1307,8 @@ var _ = Describe("Ironic object tests", func() {
 	})
 
 	It("networking service uses user-provided switch secrets", Label("networking-user-secret", "networking"), func() {
+		helpers.SkipIfVersionBefore("35.0")
+
 		name := types.NamespacedName{
 			Name:      "test-ironic",
 			Namespace: namespace,
@@ -1392,6 +1396,8 @@ var _ = Describe("Ironic object tests", func() {
 	})
 
 	It("networking service reports missing label on user-provided secret", Label("networking-missing-label", "networking"), func() {
+		helpers.SkipIfVersionBefore("35.0")
+
 		name := types.NamespacedName{
 			Name:      "test-ironic",
 			Namespace: namespace,
@@ -1442,6 +1448,8 @@ var _ = Describe("Ironic object tests", func() {
 	})
 
 	It("networking service can be enabled and disabled", Label("networking-lifecycle", "networking"), func() {
+		helpers.SkipIfVersionBefore("35.0")
+
 		name := types.NamespacedName{
 			Name:      "test-ironic",
 			Namespace: namespace,
@@ -1488,6 +1496,8 @@ var _ = Describe("Ironic object tests", func() {
 	})
 
 	It("networking service restarts on switch config change", Label("networking-restart", "networking"), func() {
+		helpers.SkipIfVersionBefore("35.0")
+
 		name := types.NamespacedName{
 			Name:      "test-ironic",
 			Namespace: namespace,


### PR DESCRIPTION
The networking service feature requires ironic-image 35.0 or newer. When running functional tests against an older ironic-image (e.g. via IRONIC_CUSTOM_VERSION=34.0 in the ironic-image CI), the networking tests must be skipped to avoid false failures.

Add SkipIfVersionBefore helper and gate all networking tests on 35.0.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:


Fixes the functional test failure in: https://github.com/metal3-io/ironic-image/pull/1011

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [X] E2E tests have been added, if necessary.
