### PR TITLE
Add timeouts for all workflows

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build_controller:
     name: Build Ironic-standalone-operator container image
+    timeout-minutes: 10
     if: github.repository == 'metal3-io/ironic-standalone-operator'
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -26,6 +27,7 @@ jobs:
       run: make test
   container:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -40,6 +42,7 @@ jobs:
       run: podman build .
   manifests:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,6 +14,7 @@ permissions: {}
 jobs:
   build:
     name: Build
+    timeout-minutes: 5
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/functional-periodic-main.yml
+++ b/.github/workflows/functional-periodic-main.yml
@@ -15,6 +15,7 @@ jobs:
     with:
       ref: main
       fail-fast: false
+    timeout-minutes: 90
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/functional-periodic-release-0.7.yml
+++ b/.github/workflows/functional-periodic-release-0.7.yml
@@ -15,6 +15,7 @@ jobs:
     with:
       ref: release-0.7
       fail-fast: false
+    timeout-minutes: 90
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/functional-periodic-release-0.8.yml
+++ b/.github/workflows/functional-periodic-release-0.8.yml
@@ -15,6 +15,7 @@ jobs:
     with:
       ref: release-0.8
       fail-fast: false
+    timeout-minutes: 90
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/functional-periodic-release-0.9.yml
+++ b/.github/workflows/functional-periodic-release-0.9.yml
@@ -15,6 +15,7 @@ jobs:
     with:
       ref: release-0.9
       fail-fast: false
+    timeout-minutes: 90
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/functional-pr.yml
+++ b/.github/workflows/functional-pr.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   functional-tests:
     uses: ./.github/workflows/functional.yml
+    timeout-minutes: 90
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -24,6 +24,7 @@ jobs:
       CLUSTER_TYPE: minikube
       LOGDIR: /tmp/logs
       JUNIT_OUTPUT: /tmp/logs/report.xml
+    timeout-minutes: 90
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,6 +10,7 @@ jobs:
   golangci-lint:
     name: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/local-ironic.yml
+++ b/.github/workflows/local-ironic.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     env:

--- a/.github/workflows/pr-gh-workflow-approve.yaml
+++ b/.github/workflows/pr-gh-workflow-approve.yaml
@@ -14,7 +14,7 @@ jobs:
   approve:
     name: Approve on ok-to-test
     runs-on: ubuntu-latest
-
+    timeout-minutes: 5
     permissions:
       actions: write
 

--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -12,3 +12,4 @@ jobs:
     uses: metal3-io/project-infra/.github/workflows/pr-link-check.yml@main # zizmor: ignore[unpinned-uses]
     with:
       upstream: https://github.com/metal3-io/ironic-standalone-operator.git
+    timeout-minutes: 10

--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -9,4 +9,5 @@ on:
 jobs:
   verify:
     name: verify PR contents
+    timeout-minutes: 5
     uses: metal3-io/project-infra/.github/workflows/pr-verifier.yaml@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       release_tag: ${{ steps.release-version.outputs.release_version }}
     if: github.repository == 'metal3-io/ironic-standalone-operator'
@@ -88,6 +89,7 @@ jobs:
   release:
     name: create draft release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: push_release_tags
     permissions:
       contents: write
@@ -139,6 +141,7 @@ jobs:
       id-token: write
     needs: push_release_tags
     name: Build IrSO container image
+    timeout-minutes: 10
     if: github.repository == 'metal3-io/ironic-standalone-operator'
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:

--- a/.github/workflows/scheduled-link-check.yml
+++ b/.github/workflows/scheduled-link-check.yml
@@ -14,4 +14,5 @@ permissions:
 
 jobs:
   check-links:
+    timeout-minutes: 5
     uses: metal3-io/project-infra/.github/workflows/scheduled-link-check.yml@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/validate-security-insights.yml
+++ b/.github/workflows/validate-security-insights.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     steps:

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   yamllint-check:
     name: yaml-lint
+    timeout-minutes: 5
     uses: metal3-io/project-infra/.github/workflows/yamllint.yaml@main # zizmor: ignore[unpinned-uses]
     with:
       ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,6 +16,7 @@ permissions: {}
 jobs:
   zizmor:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: Github workflows might get stuck and it takes 6 hours to cancel by default 
Timeouts were set as follows:

- 5 minutes for all the smaller workflows (that are 30 seconds or less on average) 
- 10 minutes for medium workflows (Average around 2 max around 5) 
- 15 for one workflow which reached up to 8 minutes
- 90 for the largest workflows (most average around 20 but the highest is can reach 90 minutes)


<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes https://github.com/metal3-io/ironic-standalone-operator/issues/667
 
