### PR TITLE
:seedling: Remove timeout from caller periodic workflows

### DIFF
--- a/.github/workflows/functional-periodic-main.yml
+++ b/.github/workflows/functional-periodic-main.yml
@@ -15,7 +15,6 @@ jobs:
     with:
       ref: main
       fail-fast: false
-    timeout-minutes: 90
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/functional-periodic-release-0.7.yml
+++ b/.github/workflows/functional-periodic-release-0.7.yml
@@ -15,7 +15,6 @@ jobs:
     with:
       ref: release-0.7
       fail-fast: false
-    timeout-minutes: 90
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/functional-periodic-release-0.8.yml
+++ b/.github/workflows/functional-periodic-release-0.8.yml
@@ -15,7 +15,6 @@ jobs:
     with:
       ref: release-0.8
       fail-fast: false
-    timeout-minutes: 90
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/functional-periodic-release-0.9.yml
+++ b/.github/workflows/functional-periodic-release-0.9.yml
@@ -15,7 +15,6 @@ jobs:
     with:
       ref: release-0.9
       fail-fast: false
-    timeout-minutes: 90
     permissions:
       checks: write
       contents: read


### PR DESCRIPTION
https://github.com/metal3-io/ironic-standalone-operator/pull/698/ introduced a faulty change in the periodic workflow files. Timeouts must be set inside the reusable workflow itself. This caused the periodics to be non functional.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
