### PR TITLE
:seedling: fix dependabots build workflow step

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -24,7 +24,8 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        persist-credentials: false
+        # Required for EndBug/add-and-commit to push generated code updates
+        persist-credentials: true
     - name: Calculate go version
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The EndBug's step needs the persisted credentials to make the push.
