### PR TITLE
:seedling: workflows reusing other workflows cannot have timeouts

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -14,7 +14,6 @@ on:
 jobs:
   build_controller:
     name: Build Ironic-standalone-operator container image
-    timeout-minutes: 10
     if: github.repository == 'metal3-io/ironic-standalone-operator'
     permissions:
       contents: read

--- a/.github/workflows/functional-pr.yml
+++ b/.github/workflows/functional-pr.yml
@@ -9,7 +9,6 @@ permissions: {}
 jobs:
   functional-tests:
     uses: ./.github/workflows/functional.yml
-    timeout-minutes: 90
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -12,4 +12,3 @@ jobs:
     uses: metal3-io/project-infra/.github/workflows/pr-link-check.yml@main # zizmor: ignore[unpinned-uses]
     with:
       upstream: https://github.com/metal3-io/ironic-standalone-operator.git
-    timeout-minutes: 10

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,7 +141,6 @@ jobs:
       id-token: write
     needs: push_release_tags
     name: Build IrSO container image
-    timeout-minutes: 10
     if: github.repository == 'metal3-io/ironic-standalone-operator'
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:

--- a/.github/workflows/scheduled-link-check.yml
+++ b/.github/workflows/scheduled-link-check.yml
@@ -14,5 +14,4 @@ permissions:
 
 jobs:
   check-links:
-    timeout-minutes: 5
     uses: metal3-io/project-infra/.github/workflows/scheduled-link-check.yml@main # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
Its a syntax error. The timeout must be on the reused workflow side.

All reusing workflows in IRSO, including release.yaml are broken.
