### PR TITLE
🌱 Remove zizmor inline ignore for release-0.10

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
     if: github.repository == 'metal3-io/ironic-standalone-operator'
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked]
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
     - name: Get changed files

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -7,3 +7,8 @@ rules:
   dependabot-cooldown:
     config:
       days: 3
+
+  # persist-credentials needed later in the workflow
+  artipacked:
+    ignore:
+    - release.yaml


### PR DESCRIPTION
Removed the # zizmor: ignore[artipacked] inline suppression comment from .github/workflows/release.yaml. The artipacked warning is now handled via a targeted ignore rule in .zizmor.yml at the repo root instead, since persist-credentials: false cannot be used here as credentials are needed later in the workflow.