### PR TITLE
🐛Hardening build tool artifacts downloads for verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,6 @@ KUSTOMIZE_VERSION ?= v5.4.2
 CONTROLLER_TOOLS_VERSION ?= v0.17.0
 GOLANGCI_LINT_VERSION ?= v2.10.1
 
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
 $(KUSTOMIZE): $(LOCALBIN)
@@ -252,7 +251,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
 		rm -rf $(LOCALBIN)/kustomize; \
 	fi
-	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+	test -s $(LOCALBIN)/kustomize || GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
@@ -285,6 +284,15 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
 	$(CONTAINER_RUNTIME) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+## OPM checksums for v1.23.0 (from https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/checksums.txt)
+OPM_VERSION = v1.23.0
+OPM_SHA256_linux_amd64   = dc0d4d287fef23f165c837b2e6cb68e2506ff295dc57110b9bfe3b553359eb36
+OPM_SHA256_linux_arm64   = 00281c9239ad0aa036a8123bd4c6bb8c840fcab53d49bb65328d35b416e7ba60
+OPM_SHA256_linux_ppc64le = 87772cd2826c9154a87e49ea032a3c385ee5cc3b696641f9e0a3d564085873d7
+OPM_SHA256_linux_s390x   = d56e4cc0dcd3cb81110e7bcfabb15d2d1e08084ccb6baa51ee77be71e70a4a20
+OPM_SHA256_darwin_amd64  = 60d78a3b8bb7e19606df4551606eb848e291186ebee510dc1c0aba68d18302e6
+OPM_SHA256_darwin_arm64  = e57e2b5fac29657956f8da0fdf73c7eae6eaa58920d53d1594d83bbad20f28b1
+
 .PHONY: opm
 OPM = ./bin/opm
 opm: ## Download opm locally if necessary.
@@ -294,7 +302,10 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
+	curl -fsSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
+ 	EXPECTED="$(OPM_SHA256_$(shell go env GOOS)_$(shell go env GOARCH))" ;\
+ 	test -n "$${EXPECTED}" || { echo "No pinned SHA256 for opm platform $${OS}-$${ARCH}" >&2; exit 1; } ;\
+ 	if command -v sha256sum >/dev/null 2>&1; then echo "$${EXPECTED}  $(OPM)" | sha256sum -c -; else echo "$${EXPECTED}  $(OPM)" | shasum -a 256 -c -; fi ;\
 	chmod +x $(OPM) ;\
 	}
 else


### PR DESCRIPTION
Hardening the kustomize and OPM build tool artifacts download for verification. The checksum logic in the Makefile will correctly block execution if the binary is tampered with.

Solution Used: 
kustomize: pin the install script URL to a specific commit SHA rather than the master branch ref. Download the script to a temporary file, verify its SHA256 checksum against a known-good value before executing it. Alternatively, install kustomize via go install with a pinned version, which benefits from go.sum integrity verification. Remove the ?= override capability for KUSTOMIZE_INSTALL_SCRIPT or validate it against an allowlist of trusted URLs.

OPM: after downloading the binary, verify its SHA256 checksum against the expected value published in the release (e.g., via a checksums.txt file from the same release), or verify the GPG signature if the project provides one. Pin the expected checksum in the Makefile or a companion file under version control so it is reviewed alongside version bumps.