### PR TITLE
🌱 Harden hack script against WORKDIR volume mount injection

### DIFF
--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -5,7 +5,6 @@ set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
-WORKDIR="${WORKDIR:-/workdir}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
     TOP_DIR="${1:-.}"
@@ -13,9 +12,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
-        --volume "${PWD}:${WORKDIR}:ro,z" \
+        --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
-        --workdir "${WORKDIR}" \
+        --workdir /workdir \
         docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63 \
-        "${WORKDIR}"/hack/shellcheck.sh "$@"
+        /workdir/hack/shellcheck.sh "$@"
 fi


### PR DESCRIPTION
Affects the following scripts under the hack/ directory:

- shellcheck.sh

This script read WORKDIR from the env and insert it directly into the
container's --volume mount specification. Because the volume spec is colon-delimited
(`host:target:options`), a WORKDIR value containing a colon could alter how the mount
is parsed.

This change removes the WORKDIR var and hardcodes the container path to /workdir,
which matches the pattern already used in several other metal3 repos. Since /workdir
was already the default, there is no change in behavior for normal use, but the
injection surface is eliminated.

**NOTE**: the other scripts in this repo (gomod.sh, manifestlint.sh, and markdownlint.sh) already had hardcode /workdir. This change brings shellcheck.sh in line with them.