### PR TITLE
🌱 Remove leftover MariaDB image code

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -159,7 +159,7 @@ func main() {
 
 	setupLog.Info("enabling features", "FeatureGate", metal3iov1alpha1.CurrentFeatureGate.String())
 
-	versionInfo, err := ironic.NewVersionInfo(ironicImages, ironicVersion, databaseImage)
+	versionInfo, err := ironic.NewVersionInfo(ironicImages, ironicVersion)
 	if err != nil {
 		setupLog.Error(err, "invalid ironic-version")
 		os.Exit(1)

--- a/cmd/run-local-ironic/main.go
+++ b/cmd/run-local-ironic/main.go
@@ -84,7 +84,7 @@ func main() {
 		tempFile.Close() // Close immediately, we just need the name
 	}
 
-	versionInfo, err := ironic.NewVersionInfo(metal3api.Images{}, "", "")
+	versionInfo, err := ironic.NewVersionInfo(metal3api.Images{}, "")
 	if err != nil {
 		// This cannot happen in reality
 		setupLog.Error(err, "invalid ironic version")

--- a/pkg/ironic/version.go
+++ b/pkg/ironic/version.go
@@ -14,7 +14,6 @@ const (
 var (
 	// NOTE(dtantsur): defaultVersion must be updated after branching.
 	defaultVersion                = metal3api.VersionLatest
-	defaultMariaDBImage           = defaultRegistry + "/mariadb:latest"
 	defaultRamdiskDownloaderImage = defaultRegistry + "/ironic-ipa-downloader:latest"
 	defaultKeepalivedImage        = defaultRegistry + "/keepalived:latest"
 
@@ -29,14 +28,13 @@ var (
 type VersionInfo struct {
 	InstalledVersion       metal3api.Version
 	IronicImage            string
-	MariaDBImage           string
 	RamdiskDownloaderImage string
 	AgentBranch            string
 	KeepalivedImage        string
 }
 
 // Creates a version info from images and version.
-func NewVersionInfo(ironicImages metal3api.Images, ironicVersion string, databaseImage string) (result VersionInfo, err error) {
+func NewVersionInfo(ironicImages metal3api.Images, ironicVersion string) (result VersionInfo, err error) {
 	if ironicVersion != "" {
 		parsedVersion, err := metal3api.ParseVersion(ironicVersion)
 		if err != nil {
@@ -68,12 +66,6 @@ func NewVersionInfo(ironicImages metal3api.Images, ironicVersion string, databas
 
 	if ironicImages.DeployRamdiskBranch != "" {
 		result.AgentBranch = ironicImages.DeployRamdiskBranch
-	}
-
-	if databaseImage != "" {
-		result.MariaDBImage = databaseImage
-	} else {
-		result.MariaDBImage = defaultMariaDBImage
 	}
 
 	return result, nil

--- a/pkg/ironic/version_test.go
+++ b/pkg/ironic/version_test.go
@@ -32,7 +32,6 @@ func TestWithIronicOverrides(t *testing.T) {
 				IronicImage:            "quay.io/metal3-io/ironic:latest",
 				KeepalivedImage:        "quay.io/metal3-io/keepalived:latest",
 				RamdiskDownloaderImage: "quay.io/metal3-io/ironic-ipa-downloader:latest",
-				MariaDBImage:           "quay.io/metal3-io/mariadb:latest",
 			},
 		},
 		{
@@ -56,7 +55,6 @@ func TestWithIronicOverrides(t *testing.T) {
 				IronicImage:            "myorg/ironic:tag",
 				KeepalivedImage:        "myorg/keepalived:tag",
 				RamdiskDownloaderImage: "myorg/ramdisk-downloader:tag",
-				MariaDBImage:           "quay.io/metal3-io/mariadb:latest",
 			},
 		},
 		{
@@ -73,7 +71,6 @@ func TestWithIronicOverrides(t *testing.T) {
 				IronicImage:            "quay.io/metal3-io/ironic:release-38.0",
 				KeepalivedImage:        "quay.io/metal3-io/keepalived:latest",
 				RamdiskDownloaderImage: "quay.io/metal3-io/ironic-ipa-downloader:latest",
-				MariaDBImage:           "quay.io/metal3-io/mariadb:latest",
 			},
 		},
 		{
@@ -90,7 +87,6 @@ func TestWithIronicOverrides(t *testing.T) {
 				IronicImage:            "quay.io/metal3-io/ironic:release-37.0",
 				KeepalivedImage:        "quay.io/metal3-io/keepalived:latest",
 				RamdiskDownloaderImage: "quay.io/metal3-io/ironic-ipa-downloader:latest",
-				MariaDBImage:           "quay.io/metal3-io/mariadb:latest",
 			},
 		},
 		{
@@ -108,7 +104,7 @@ func TestWithIronicOverrides(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			defaults, err := NewVersionInfo(tc.DefaultIronicImages, tc.DefaultIronicVersion, tc.DefaultDatabaseImage)
+			defaults, err := NewVersionInfo(tc.DefaultIronicImages, tc.DefaultIronicVersion)
 			require.NoError(t, err)
 			result, err := defaults.WithIronicOverrides(&tc.Ironic)
 			if tc.ExpectError != "" {


### PR DESCRIPTION
Cleans up the unused MariaDBImage code that pointed at the old, now archive metal3-io/mariadb image. Nothing used this code anymore, so removing it doesnt chnage the behaviour.

The `--mariadb-image` flag still shows its "use MariaDB Operator instead" message.