### PR TITLE
:sparkles: Switch to Ironic 38.0 by default, prepare release-0.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ endif
 
 # Image URL to use all building/pushing image targets
 IMG_NO_TAG ?= quay.io/metal3-io/ironic-standalone-operator
-IMG ?= $(IMG_NO_TAG):latest
+IMG ?= $(IMG_NO_TAG):release-0.11
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -33,8 +33,6 @@ var (
 	Version380    = Version{Major: 38, Minor: 0}
 	Version370    = Version{Major: 37, Minor: 0}
 	Version350    = Version{Major: 35, Minor: 0}
-	Version340    = Version{Major: 34, Minor: 0}
-	Version330    = Version{Major: 33, Minor: 0}
 )
 
 // SupportedVersions is a mapping of supported versions to container image tags.
@@ -47,8 +45,6 @@ var SupportedVersions = map[Version]string{
 	Version380:    "release-38.0",
 	Version370:    "release-37.0",
 	Version350:    "release-35.0",
-	Version340:    "release-34.0",
-	Version330:    "release-33.0",
 }
 
 // Inspection defines inspection settings.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,7 +44,7 @@ spec:
         envFrom:
         - configMapRef:
             name: ironic-standalone-operator-config
-        image: quay.io/metal3-io/ironic-standalone-operator:latest
+        image: quay.io/metal3-io/ironic-standalone-operator:release-0.11
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/ironic/validation_test.go
+++ b/pkg/ironic/validation_test.go
@@ -444,7 +444,7 @@ func TestValidateIronic(t *testing.T) {
 		{
 			Scenario: "with version",
 			Ironic: metal3api.IronicSpec{
-				Version: "33.0",
+				Version: "35.0",
 			},
 		},
 		{
@@ -459,7 +459,7 @@ func TestValidateIronic(t *testing.T) {
 			Ironic: metal3api.IronicSpec{
 				Version: "42.42",
 			},
-			ExpectedError: "version 42.42 is not supported, supported versions are 33.0, 34.0, 35.0, 37.0, 38.0, latest",
+			ExpectedError: "version 42.42 is not supported, supported versions are 35.0, 37.0, 38.0, latest",
 		},
 		{
 			Scenario: "change existing database config",

--- a/pkg/ironic/version.go
+++ b/pkg/ironic/version.go
@@ -13,7 +13,7 @@ const (
 
 var (
 	// NOTE(dtantsur): defaultVersion must be updated after branching.
-	defaultVersion                = metal3api.VersionLatest
+	defaultVersion                = metal3api.Version380
 	defaultRamdiskDownloaderImage = defaultRegistry + "/ironic-ipa-downloader:latest"
 	defaultKeepalivedImage        = defaultRegistry + "/keepalived:latest"
 

--- a/pkg/ironic/version.go
+++ b/pkg/ironic/version.go
@@ -17,9 +17,6 @@ var (
 	defaultRamdiskDownloaderImage = defaultRegistry + "/ironic-ipa-downloader:latest"
 	defaultKeepalivedImage        = defaultRegistry + "/keepalived:latest"
 
-	versionBMCCA      = metal3api.Version330
-	versionNetworking = metal3api.Version350
-
 	// versionMultiRangeDHCP gates ExtraRanges: split DHCP_RANGE and
 	// DHCP_OPTIONS support lands in Ironic 37.0.
 	versionMultiRangeDHCP = metal3api.Version370
@@ -113,14 +110,6 @@ func (versionInfo VersionInfo) WithIronicOverrides(ironic *metal3api.Ironic) (Ve
 // requested features. Must be called before EnsureIronic or
 // EnsureIronicNetworking.
 func CheckVersion(resources Resources, version metal3api.Version) error {
-	if (resources.BMCCASecret != nil || resources.BMCCAConfigMap != nil) && version.Compare(versionBMCCA) < 0 {
-		return errors.New("using tls.bmcCA or tls.bmcCAName is only possible for Ironic 33.0 or newer")
-	}
-
-	if resources.Ironic.IsNetworkingServiceEnabled() && version.Compare(versionNetworking) < 0 {
-		return errors.New("networking service is only supported in Ironic 35.0 or newer")
-	}
-
 	if dhcp := resources.Ironic.Spec.Networking.DHCP; dhcp != nil && len(dhcp.ExtraRanges) > 0 && version.Compare(versionMultiRangeDHCP) < 0 {
 		return errors.New("networking.dhcp.extraRanges requires Ironic 37.0 or newer")
 	}

--- a/pkg/ironic/version_test.go
+++ b/pkg/ironic/version_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	metal3api "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
@@ -28,8 +27,8 @@ func TestWithIronicOverrides(t *testing.T) {
 
 			Expected: VersionInfo{
 				// NOTE(dtantsur): this value will change on stable branches
-				InstalledVersion:       metal3api.VersionLatest,
-				IronicImage:            "quay.io/metal3-io/ironic:latest",
+				InstalledVersion:       metal3api.Version380,
+				IronicImage:            "quay.io/metal3-io/ironic:release-38.0",
 				KeepalivedImage:        "quay.io/metal3-io/keepalived:latest",
 				RamdiskDownloaderImage: "quay.io/metal3-io/ironic-ipa-downloader:latest",
 			},
@@ -51,7 +50,7 @@ func TestWithIronicOverrides(t *testing.T) {
 			Expected: VersionInfo{
 				AgentBranch: "stable/x.y",
 				// NOTE(dtantsur): this value will change on stable branches
-				InstalledVersion:       metal3api.VersionLatest,
+				InstalledVersion:       metal3api.Version380,
 				IronicImage:            "myorg/ironic:tag",
 				KeepalivedImage:        "myorg/keepalived:tag",
 				RamdiskDownloaderImage: "myorg/ramdisk-downloader:tag",
@@ -124,18 +123,6 @@ func TestPrometheusExporterVersionCheck(t *testing.T) {
 		enabled       bool
 		expectedError string
 	}{
-		{
-			name:          "PrometheusExporter with version 33.0",
-			version:       metal3api.Version330,
-			enabled:       true,
-			expectedError: "",
-		},
-		{
-			name:          "PrometheusExporter with version 34.0",
-			version:       metal3api.Version340,
-			enabled:       true,
-			expectedError: "",
-		},
 		{
 			name:          "PrometheusExporter with version 35.0",
 			version:       metal3api.Version350,
@@ -253,19 +240,6 @@ func TestMultiRangeDHCPVersionCheck(t *testing.T) {
 			},
 			expectedError: "networking.dhcp.extraRanges requires Ironic 37.0 or newer",
 		},
-		{
-			name:    "ExtraRanges on 34.0 is rejected",
-			version: metal3api.Version340,
-			dhcp: &metal3api.DHCP{
-				NetworkCIDR: "192.0.2.0/24",
-				RangeBegin:  "192.0.2.10",
-				RangeEnd:    "192.0.2.100",
-				ExtraRanges: []metal3api.DHCPRange{
-					{NetworkCIDR: "198.51.100.0/24", RangeBegin: "198.51.100.10", RangeEnd: "198.51.100.100"},
-				},
-			},
-			expectedError: "networking.dhcp.extraRanges requires Ironic 37.0 or newer",
-		},
 	}
 
 	for _, tc := range testCases {
@@ -277,149 +251,6 @@ func TestMultiRangeDHCPVersionCheck(t *testing.T) {
 				},
 			}
 			err := CheckVersion(Resources{Ironic: ironic}, tc.version)
-			if tc.expectedError != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedError)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestBMCCAVersionCheck(t *testing.T) {
-	testCases := []struct {
-		name          string
-		version       metal3api.Version
-		expectedError string
-	}{
-		{
-			name:          "BMCCA with version 38.0",
-			version:       metal3api.Version380,
-			expectedError: "",
-		},
-		{
-			name:          "BMCCA with version 37.0",
-			version:       metal3api.Version370,
-			expectedError: "",
-		},
-		{
-			name:          "BMCCA with version 35.0",
-			version:       metal3api.Version350,
-			expectedError: "",
-		},
-		{
-			name:          "BMCCA with version 34.0",
-			version:       metal3api.Version340,
-			expectedError: "",
-		},
-		{
-			name:          "BMCCA with version 33.0",
-			version:       metal3api.Version330,
-			expectedError: "",
-		},
-		{
-			name:          "BMCCA with latest version",
-			version:       metal3api.VersionLatest,
-			expectedError: "",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			bmcSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bmc-ca",
-					Namespace: "test",
-				},
-				Data: map[string][]byte{
-					"ca.crt": []byte("test-ca-cert"),
-				},
-			}
-
-			ironic := &metal3api.Ironic{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-ironic",
-					Namespace: "test",
-				},
-				Spec: metal3api.IronicSpec{
-					TLS: metal3api.TLS{
-						BMCCAName: "bmc-ca",
-					},
-				},
-			}
-
-			resources := Resources{
-				Ironic:      ironic,
-				BMCCASecret: bmcSecret,
-			}
-
-			err := CheckVersion(resources, tc.version)
-
-			if tc.expectedError != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedError)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestNetworkingVersionCheck(t *testing.T) {
-	testCases := []struct {
-		name          string
-		version       metal3api.Version
-		expectedError string
-	}{
-		{
-			name:    "networking with latest version",
-			version: metal3api.VersionLatest,
-		},
-		{
-			name:    "networking with version 38.0",
-			version: metal3api.Version380,
-		},
-		{
-			name:    "networking with version 37.0",
-			version: metal3api.Version370,
-		},
-		{
-			name:    "networking with version 35.0",
-			version: metal3api.Version350,
-		},
-		{
-			name:          "networking with version 34.0",
-			version:       metal3api.Version340,
-			expectedError: "networking service is only supported in Ironic 35.0 or newer",
-		},
-		{
-			name:          "networking with version 33.0",
-			version:       metal3api.Version330,
-			expectedError: "networking service is only supported in Ironic 35.0 or newer",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ironic := &metal3api.Ironic{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-ironic",
-					Namespace: "test",
-				},
-				Spec: metal3api.IronicSpec{
-					NetworkingService: &metal3api.NetworkingService{
-						Enabled: true,
-					},
-				},
-			}
-
-			resources := Resources{
-				Ironic: ironic,
-			}
-
-			err := CheckVersion(resources, tc.version)
-
 			if tc.expectedError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.expectedError)

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -62,8 +62,6 @@ import (
 const (
 	// NOTE(dtantsur): latest is now at least 1.104, so we can rely on this
 	// value to check that specifying Version: 35.0 actually installs 35.0.
-	apiVersionIn330 = "1.104"
-	apiVersionIn340 = "1.109"
 	apiVersionIn350 = "1.111"
 	apiVersionIn370 = "1.112"
 	apiVersionIn380 = "1.113"
@@ -985,14 +983,6 @@ var _ = Describe("Ironic resource", func() {
 		VerifyIronic(ironic, TestAssumptions{withTLS: true})
 	})
 
-	It("creates Ironic 33.0 and upgrades to 34.0", Label("v330-to-340", "upgrade"), func() {
-		testUpgrade("33.0", "34.0", apiVersionIn330, apiVersionIn340, namespace)
-	})
-
-	It("creates Ironic 34.0 and upgrades to 35.0", Label("v340-to-350", "upgrade"), func() {
-		testUpgrade("34.0", "35.0", apiVersionIn340, apiVersionIn350, namespace)
-	})
-
 	It("creates Ironic 35.0 and upgrades to 37.0", Label("v350-to-370", "upgrade"), func() {
 		testUpgrade("35.0", "37.0", apiVersionIn350, apiVersionIn370, namespace)
 	})
@@ -1005,7 +995,7 @@ var _ = Describe("Ironic resource", func() {
 		testUpgrade("38.0", "latest", apiVersionIn380, "", namespace)
 	})
 
-	It("creates Ironic 33.0 with database, then upgrades it to 34.0, then 35.0, then 37.0, then 38.0", Label("db-v330-to-340-to-350-to-370-to-380", "upgrade"), func() {
+	It("creates Ironic 35.0 with database, then upgrades it to 37.0, then 38.0", Label("db-v350-to-370-to-380", "upgrade"), func() {
 		helpers.SkipIfCustomImage()
 
 		name := types.NamespacedName{
@@ -1015,7 +1005,7 @@ var _ = Describe("Ironic resource", func() {
 
 		ironic := helpers.NewIronic(ctx, k8sClient, name, metal3api.IronicSpec{
 			Database: helpers.CreateDatabase(ctx, k8sClient, name),
-			Version:  "33.0",
+			Version:  "35.0",
 		})
 		DeferCleanup(func() {
 			CollectLogs(namespace)
@@ -1023,33 +1013,13 @@ var _ = Describe("Ironic resource", func() {
 		})
 
 		ironic = WaitForIronic(name)
-		VerifyIronic(ironic, TestAssumptions{maxAPIVersion: apiVersionIn330})
-
-		By("upgrading to Ironic 34.0")
-
-		patch := client.MergeFrom(ironic.DeepCopy())
-		ironic.Spec.Version = "34.0"
-		err := k8sClient.Patch(ctx, ironic, patch)
-		Expect(err).NotTo(HaveOccurred())
-
-		ironic = WaitForUpgrade(name, "34.0")
-		VerifyIronic(ironic, TestAssumptions{maxAPIVersion: apiVersionIn340})
-
-		By("upgrading to Ironic 35.0")
-
-		patch = client.MergeFrom(ironic.DeepCopy())
-		ironic.Spec.Version = "35.0"
-		err = k8sClient.Patch(ctx, ironic, patch)
-		Expect(err).NotTo(HaveOccurred())
-
-		ironic = WaitForUpgrade(name, "35.0")
 		VerifyIronic(ironic, TestAssumptions{maxAPIVersion: apiVersionIn350})
 
 		By("upgrading to Ironic 37.0")
 
-		patch = client.MergeFrom(ironic.DeepCopy())
+		patch := client.MergeFrom(ironic.DeepCopy())
 		ironic.Spec.Version = "37.0"
-		err = k8sClient.Patch(ctx, ironic, patch)
+		err := k8sClient.Patch(ctx, ironic, patch)
 		Expect(err).NotTo(HaveOccurred())
 
 		ironic = WaitForUpgrade(name, "37.0")
@@ -1076,7 +1046,7 @@ var _ = Describe("Ironic resource", func() {
 
 		ironic := helpers.NewIronic(ctx, k8sClient, name, metal3api.IronicSpec{
 			Database: helpers.CreateDatabase(ctx, k8sClient, name),
-			Version:  "34.0",
+			Version:  "37.0",
 		})
 		DeferCleanup(func() {
 			CollectLogs(namespace)
@@ -1084,24 +1054,16 @@ var _ = Describe("Ironic resource", func() {
 		})
 
 		ironic = WaitForIronic(name)
-		VerifyIronic(ironic, TestAssumptions{maxAPIVersion: apiVersionIn340})
+		VerifyIronic(ironic, TestAssumptions{maxAPIVersion: apiVersionIn370})
 
-		By("downgrading to Ironic 33.0")
+		By("downgrading to Ironic 35.0")
 
 		patch := client.MergeFrom(ironic.DeepCopy())
-		ironic.Spec.Version = "33.0"
+		ironic.Spec.Version = "35.0"
 		err := k8sClient.Patch(ctx, ironic, patch)
 		Expect(err).NotTo(HaveOccurred())
 
 		WaitForIronicFailure(name, "Ironic does not support downgrades", true)
-	})
-
-	It("creates Ironic 33.0 with HA and upgrades to 34.0", Label("ha-v330-to-340", "ha", "upgrade"), func() {
-		testUpgradeHA("33.0", "34.0", apiVersionIn330, apiVersionIn340, namespace)
-	})
-
-	It("creates Ironic 34.0 with HA and upgrades to 35.0", Label("ha-v340-to-350", "ha", "upgrade"), func() {
-		testUpgradeHA("34.0", "35.0", apiVersionIn340, apiVersionIn350, namespace)
 	})
 
 	It("creates Ironic 35.0 with HA and upgrades to 37.0", Label("ha-v350-to-370", "ha", "upgrade"), func() {


### PR DESCRIPTION
Also drop support for Ironic 33.0 and 34.0
