### PR TITLE
Revert "🌱 Remove PR Verifier GitHub Action workflow in favor of Prow"

### DIFF
--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -1,0 +1,13 @@
+name: PR Verifier
+
+permissions: {}
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+jobs:
+  verify:
+    name: verify PR contents
+    timeout-minutes: 5
+    uses: metal3-io/project-infra/.github/workflows/pr-verifier.yaml@main # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
Reverts metal3-io/ironic-standalone-operator#798

The prow pr-verifier job fails for batch jobs (when multiple PRs are merged together) since no PULL_TITLE is set for them.