### PR TITLE
🌱 Revert "Remove PR Verifier GitHub Action workflow in favor of Prow"

### DIFF
--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -1,0 +1,13 @@
+name: PR Verifier
+
+permissions: {}
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+jobs:
+  verify:
+    name: verify PR contents
+    timeout-minutes: 5
+    uses: metal3-io/project-infra/.github/workflows/pr-verifier.yaml@main # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
**What this PR does / why we need it**:

The pr-verifier job fails for batch jobs (when multiple PRs are merged together) since no PULL_TITLE is set for them.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
