### PR TITLE
:seedling: Local tests: retry podman commands if they hang 

### DIFF
--- a/test/local-ironic/collect-logs.sh
+++ b/test/local-ironic/collect-logs.sh
@@ -5,9 +5,24 @@ set -ux
 
 LOGDIR="${LOGDIR:-/tmp/logs}"
 
-sudo podman ps --all | tee "${LOGDIR}/containers.txt" > /dev/null
-for cid in $(sudo podman ps --quiet); do
-    sudo podman inspect "${cid}" | tee "${LOGDIR}/${cid}.txt" > /dev/null
-    sudo podman logs "${cid}" 2>&1 | tee "${LOGDIR}/${cid}.log" > /dev/null
+# NOTE(dtantsur): podman tends to hang occasionally, work around
+run_podman() {
+    local attempts=3
+    while true; do
+        sudo timeout 15s podman "$@"
+        local result="$?"
+        # exit code 124 is timeout
+        if [[ "${result}" == "124" ]] && (( attempts > 0 )); then
+            attempts=$((attempts-1))
+        else
+            exit "${result}"
+        fi
+    done
+}
+
+run_podman ps --all | tee "${LOGDIR}/containers.txt"
+for cid in $(run_podman ps --quiet); do
+    run_podman inspect "${cid}" | tee "${LOGDIR}/${cid}.txt" > /dev/null
+    run_podman logs "${cid}" 2>&1 | tee "${LOGDIR}/${cid}.log" > /dev/null
 done
 sudo chown -R "${USER}" "${LOGDIR}"


### PR DESCRIPTION
It happens under unclear conditions, and the resulting github actions
report is very unhelpful. Retry several times and let collection
continue.

Also don't silence the ps output: it can be helpful for debugging.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
