### PR TITLE
WIP introduce accessIP option

### DIFF
--- a/api/v1alpha1/ironic_types.go
+++ b/api/v1alpha1/ironic_types.go
@@ -190,6 +190,21 @@ type KeepalivedConfig struct {
 
 // Networking defines networking settings for Ironic.
 type Networking struct {
+	// AccessIP is the IP address through which Ironic must be accessed for
+	// downloading cached images and for ramdisk callbacks. This setting
+	// overrides ipAddress (explicitly provided or implicitly derived) for
+	// external traffic.
+	//
+	// Unlike externalIP, this setting applies to all deployments, not just
+	// virtual media. If DHCP is enabled, accessIP will be used for
+	// downloading iPXE artifacts as well. Also unlike externalIP, this IP
+	// must be reachable from the Ironic pod as well.
+	//
+	// Cannot be provided for a highly available architecture since there
+	// is no way to access several image cache servers through the same IP.
+	// +optional
+	AccessIP string `json:"accessIP,omitempty"`
+
 	// APIPort is the public port used for Ironic.
 	// +kubebuilder:default=6385
 	// +kubebuilder:validation:Minimum=1
@@ -214,28 +229,38 @@ type Networking struct {
 	// +optional
 	DisableHostNetwork bool `json:"disableHostNetwork,omitempty"`
 
-	// ExternalCallbackURL for Ironic API server.
+	// ExternalCallbackURL is the URL that the ramdisk will use to call
+	// back into Ironic during a virtual media deployment.
 	// Set this option when your Ironic API server is not directly accessible.
-	// Setting this option, will override URL set by networking.ingress.host.
+	//
+	// Setting this option will override URL set by networking.ingress.host.
 	// Must be set together with networking.imageServerExternalURL or networking.ingress
-	// This should only be used with virtual media deployments.
 	// Cannot be set at the same time with networking.externalIP.
 	// +kubebuilder:validation:Format=uri
 	// +optional
 	ExternalCallbackURL string `json:"externalCallbackURL,omitempty"`
 
-	// ExternalIP is used for accessing API and the image server from remote hosts.
-	// This setting only applies to virtual media deployments. The IP will not be accessed from the cluster itself.
+	// ExternalIP is the IP address through which Ironic must be accessed for
+	// downloading cached images and for ramdisk callbacks during virtual
+	// media deployments. This setting overrides ipAddress (explicitly
+	// provided or implicitly derived) for external traffic.
+	//
+	// This setting applies only to virtual media deployments and overrides
+	// accessIP. Network boot deployments are not affected by it.
+	//
 	// Cannot be set at the same time with networking.ingress, networking.externalCallbackURL, or networking.imageServerExternalURL.
 	// +optional
 	ExternalIP string `json:"externalIP,omitempty"`
 
-	// ImageServerExternalURL is to set external HTTP URL for Image server.
+	// ImageServerExternalURL is the URL used for downloading virtual media
+	// ISO images and cached instance images during a virtual media
+	// deployment.
 	// Set this option when your image server is not directly accessible.
-	// Setting this option, will override URL set by networking.ingress.host.
+	//
+	// Setting this option will override URL set by networking.ingress.host.
 	// Must be set together with networking.externalCallbackURL or networking.ingress
 	// Cannot be set at the same time with networking.externalIP.
-	// This should only be used with virtual media deployments.
+	// This setting only affects virtual media deployments.
 	// +kubebuilder:validation:Format=uri
 	// +optional
 	ImageServerExternalURL string `json:"imageServerExternalURL,omitempty"`
@@ -255,7 +280,7 @@ type Networking struct {
 	// Configure Ingress resource for Ironic services.
 	// Set this option when you are planning to deploy Ironic in a public cluster and willing to use Ingress instead of IP address on the Host Network.
 	// The API and the image server will be accessible via the hostname specified in the ingress configuration.
-	// This should only be used with virtual media deployments.
+	// This setting only affects virtual media deployments.
 	// Cannot be set at the same time with networking.externalIP.
 	// +optional
 	Ingress *Ingress `json:"ingress,omitempty"`

--- a/config/crd/bases/ironic.metal3.io_ironics.yaml
+++ b/config/crd/bases/ironic.metal3.io_ironics.yaml
@@ -178,6 +178,21 @@ spec:
               networking:
                 description: Networking defines networking settings for Ironic.
                 properties:
+                  accessIP:
+                    description: |-
+                      AccessIP is the IP address through which Ironic must be accessed for
+                      downloading cached images and for ramdisk callbacks. This setting
+                      overrides ipAddress (explicitly provided or implicitly derived) for
+                      external traffic.
+
+                      Unlike externalIP, this setting applies to all deployments, not just
+                      virtual media. If DHCP is enabled, accessIP will be used for
+                      downloading iPXE artifacts as well. Also unlike externalIP, this IP
+                      must be reachable from the Ironic pod as well.
+
+                      Cannot be provided for a highly available architecture since there
+                      is no way to access several image cache servers through the same IP.
+                    type: string
                   apiPort:
                     default: 6385
                     description: APIPort is the public port used for Ironic.
@@ -290,28 +305,38 @@ spec:
                     type: boolean
                   externalCallbackURL:
                     description: |-
-                      ExternalCallbackURL for Ironic API server.
+                      ExternalCallbackURL is the URL that the ramdisk will use to call
+                      back into Ironic during a virtual media deployment.
                       Set this option when your Ironic API server is not directly accessible.
-                      Setting this option, will override URL set by networking.ingress.host.
+
+                      Setting this option will override URL set by networking.ingress.host.
                       Must be set together with networking.imageServerExternalURL or networking.ingress
-                      This should only be used with virtual media deployments.
                       Cannot be set at the same time with networking.externalIP.
                     format: uri
                     type: string
                   externalIP:
                     description: |-
-                      ExternalIP is used for accessing API and the image server from remote hosts.
-                      This setting only applies to virtual media deployments. The IP will not be accessed from the cluster itself.
+                      ExternalIP is the IP address through which Ironic must be accessed for
+                      downloading cached images and for ramdisk callbacks during virtual
+                      media deployments. This setting overrides ipAddress (explicitly
+                      provided or implicitly derived) for external traffic.
+
+                      This setting applies only to virtual media deployments and overrides
+                      accessIP. Network boot deployments are not affected by it.
+
                       Cannot be set at the same time with networking.ingress, networking.externalCallbackURL, or networking.imageServerExternalURL.
                     type: string
                   imageServerExternalURL:
                     description: |-
-                      ImageServerExternalURL is to set external HTTP URL for Image server.
+                      ImageServerExternalURL is the URL used for downloading virtual media
+                      ISO images and cached instance images during a virtual media
+                      deployment.
                       Set this option when your image server is not directly accessible.
-                      Setting this option, will override URL set by networking.ingress.host.
+
+                      Setting this option will override URL set by networking.ingress.host.
                       Must be set together with networking.externalCallbackURL or networking.ingress
                       Cannot be set at the same time with networking.externalIP.
-                      This should only be used with virtual media deployments.
+                      This setting only affects virtual media deployments.
                     format: uri
                     type: string
                   imageServerPort:
@@ -333,7 +358,7 @@ spec:
                       Configure Ingress resource for Ironic services.
                       Set this option when you are planning to deploy Ironic in a public cluster and willing to use Ingress instead of IP address on the Host Network.
                       The API and the image server will be accessible via the hostname specified in the ingress configuration.
-                      This should only be used with virtual media deployments.
+                      This setting only affects virtual media deployments.
                       Cannot be set at the same time with networking.externalIP.
                     properties:
                       annotations:

--- a/docs/api.md
+++ b/docs/api.md
@@ -444,6 +444,24 @@ Networking defines networking settings for Ironic.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>accessIP</b></td>
+        <td>string</td>
+        <td>
+          AccessIP is the IP address through which Ironic must be accessed for
+downloading cached images and for ramdisk callbacks. This setting
+overrides ipAddress (explicitly provided or implicitly derived) for
+external traffic.
+
+Unlike externalIP, this setting applies to all deployments, not just
+virtual media. If DHCP is enabled, accessIP will be used for
+downloading iPXE artifacts as well. Also unlike externalIP, this IP
+must be reachable from the Ironic pod as well.
+
+Cannot be provided for a highly available architecture since there
+is no way to access several image cache servers through the same IP.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>apiPort</b></td>
         <td>integer</td>
         <td>
@@ -487,11 +505,12 @@ This should only be used with virtual media deployments.<br/>
         <td><b>externalCallbackURL</b></td>
         <td>string</td>
         <td>
-          ExternalCallbackURL for Ironic API server.
+          ExternalCallbackURL is the URL that the ramdisk will use to call
+back into Ironic during a virtual media deployment.
 Set this option when your Ironic API server is not directly accessible.
-Setting this option, will override URL set by networking.ingress.host.
+
+Setting this option will override URL set by networking.ingress.host.
 Must be set together with networking.imageServerExternalURL or networking.ingress
-This should only be used with virtual media deployments.
 Cannot be set at the same time with networking.externalIP.<br/>
           <br/>
             <i>Format</i>: uri<br/>
@@ -501,8 +520,14 @@ Cannot be set at the same time with networking.externalIP.<br/>
         <td><b>externalIP</b></td>
         <td>string</td>
         <td>
-          ExternalIP is used for accessing API and the image server from remote hosts.
-This setting only applies to virtual media deployments. The IP will not be accessed from the cluster itself.
+          ExternalIP is the IP address through which Ironic must be accessed for
+downloading cached images and for ramdisk callbacks during virtual
+media deployments. This setting overrides ipAddress (explicitly
+provided or implicitly derived) for external traffic.
+
+This setting applies only to virtual media deployments and overrides
+accessIP. Network boot deployments are not affected by it.
+
 Cannot be set at the same time with networking.ingress, networking.externalCallbackURL, or networking.imageServerExternalURL.<br/>
         </td>
         <td>false</td>
@@ -510,12 +535,15 @@ Cannot be set at the same time with networking.ingress, networking.externalCallb
         <td><b>imageServerExternalURL</b></td>
         <td>string</td>
         <td>
-          ImageServerExternalURL is to set external HTTP URL for Image server.
+          ImageServerExternalURL is the URL used for downloading virtual media
+ISO images and cached instance images during a virtual media
+deployment.
 Set this option when your image server is not directly accessible.
-Setting this option, will override URL set by networking.ingress.host.
+
+Setting this option will override URL set by networking.ingress.host.
 Must be set together with networking.externalCallbackURL or networking.ingress
 Cannot be set at the same time with networking.externalIP.
-This should only be used with virtual media deployments.<br/>
+This setting only affects virtual media deployments.<br/>
           <br/>
             <i>Format</i>: uri<br/>
         </td>
@@ -549,7 +577,7 @@ This should only be used with virtual media deployments.<br/>
           Configure Ingress resource for Ironic services.
 Set this option when you are planning to deploy Ironic in a public cluster and willing to use Ingress instead of IP address on the Host Network.
 The API and the image server will be accessible via the hostname specified in the ingress configuration.
-This should only be used with virtual media deployments.
+This setting only affects virtual media deployments.
 Cannot be set at the same time with networking.externalIP.<br/>
         </td>
         <td>false</td>
@@ -795,7 +823,7 @@ NetworkCIDR when set. IPv6 gateways are not supported here.<br/>
 Configure Ingress resource for Ironic services.
 Set this option when you are planning to deploy Ironic in a public cluster and willing to use Ingress instead of IP address on the Host Network.
 The API and the image server will be accessible via the hostname specified in the ingress configuration.
-This should only be used with virtual media deployments.
+This setting only affects virtual media deployments.
 Cannot be set at the same time with networking.externalIP.
 
 <table>

--- a/pkg/ironic/containers.go
+++ b/pkg/ironic/containers.go
@@ -47,18 +47,20 @@ const (
 )
 
 func buildCommonEnvVars(ironic *metal3api.Ironic) []corev1.EnvVar {
+	apiPort := strconv.Itoa(int(ironic.Spec.Networking.APIPort))
+	imagePort := strconv.Itoa(int(ironic.Spec.Networking.ImageServerPort))
 	result := []corev1.EnvVar{
 		{
 			Name:  "IRONIC_LISTEN_PORT",
-			Value: strconv.Itoa(int(ironic.Spec.Networking.APIPort)),
+			Value: apiPort,
 		},
 		{
 			Name:  "IRONIC_ACCESS_PORT",
-			Value: strconv.Itoa(int(ironic.Spec.Networking.APIPort)),
+			Value: apiPort,
 		},
 		{
 			Name:  "HTTP_PORT",
-			Value: strconv.Itoa(int(ironic.Spec.Networking.ImageServerPort)),
+			Value: imagePort,
 		},
 		{
 			Name:  "LISTEN_ALL_INTERFACES",
@@ -110,6 +112,31 @@ func buildCommonEnvVars(ironic *metal3api.Ironic) []corev1.EnvVar {
 				},
 			},
 		)
+	}
+
+	if ironic.Spec.Networking.AccessIP != "" {
+		apiScheme := "http"
+		if ironic.Spec.TLS.CertificateName != "" {
+			apiScheme = "https"
+		}
+		baseURL := joinURL(apiScheme, ironic.Spec.Networking.AccessIP, apiPort)
+		// NOTE(dtantsur): TLS support for image server is not ready yet
+		httpURL := joinURL("http", ironic.Spec.Networking.AccessIP, imagePort)
+		tftpURL := joinURL("tftp", ironic.Spec.Networking.AccessIP, "")
+		result = append(result, []corev1.EnvVar{
+			{
+				Name:  "IRONIC_BASE_URL",
+				Value: baseURL,
+			},
+			{
+				Name:  "IRONIC_HTTP_URL",
+				Value: httpURL,
+			},
+			{
+				Name:  "IRONIC_TFTP_URL",
+				Value: tftpURL,
+			},
+		}...)
 	}
 
 	if ironic.Spec.TLS.CertificateName != "" {

--- a/pkg/ironic/utils.go
+++ b/pkg/ironic/utils.go
@@ -494,3 +494,18 @@ func volumeForSecretOrConfigMap(name string, secret *corev1.Secret, configMap *c
 
 	return nil
 }
+
+// A version of net.JoinHostPort that has an optional port and schema.
+func joinURL(scheme, host, port string) string {
+	result := host
+	if strings.Contains(result, ":") {
+		result = "[" + result + "]"
+	}
+	if scheme != "" {
+		result = scheme + "://" + result
+	}
+	if port != "" {
+		result = result + ":" + port
+	}
+	return result
+}

--- a/pkg/ironic/validation.go
+++ b/pkg/ironic/validation.go
@@ -313,6 +313,10 @@ func ValidateIronic(ironic *metal3api.IronicSpec, old *metal3api.IronicSpec) err
 		return err
 	}
 
+	if err := validateIP(ironic.Networking.AccessIP); err != nil {
+		return err
+	}
+
 	if err := validateIP(ironic.Networking.ExternalIP); err != nil {
 		return err
 	}
@@ -330,6 +334,10 @@ func ValidateIronic(ironic *metal3api.IronicSpec, old *metal3api.IronicSpec) err
 
 	if ironic.HighAvailability && ironic.Networking.IPAddress != "" {
 		return errors.New("networking.ipAddress makes no sense with highly available architecture")
+	}
+
+	if ironic.HighAvailability && ironic.Networking.AccessIP != "" {
+		return errors.New("networking.accessIP cannot be used with highly available architecture")
 	}
 
 	if ironic.Networking.DHCP != nil {


### PR DESCRIPTION
This option allows overriding how Ironic is accessed for all
deployments, not just virtual media. It can be used together with
a custom Ingress configuration or with a custom DHCP solution.

While here, clean up documentation for various IP options to highlight
how they interact with each other.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
