### PR TITLE
🌱 CI: add timeout to run-local-ironic calls

### DIFF
--- a/test/local-ironic/run.sh
+++ b/test/local-ironic/run.sh
@@ -33,7 +33,7 @@ fi
 
 mkdir -p "${LOGDIR}"
 make build-run-local-ironic
-sudo ./bin/run-local-ironic --input "${IRONIC}" \
+sudo timeout 5m ./bin/run-local-ironic --input "${IRONIC}" \
     --output "${LOGDIR}/generated-${SCENARIO}.yaml" --verbose
 
 # podman returns before containers fully start, so give it a graceful period

--- a/test/local-ironic/tear-down.sh
+++ b/test/local-ironic/tear-down.sh
@@ -16,5 +16,5 @@ fi
 
 mkdir -p "${LOGDIR}"
 make build-run-local-ironic
-sudo ./bin/run-local-ironic --down --input "${IRONIC}" \
+sudo timeout 60s ./bin/run-local-ironic --down --input "${IRONIC}" \
     --output "${LOGDIR}/generated-${SCENARIO}.yaml" --verbose


### PR DESCRIPTION
These calls occasionally get stuck, preventing the job from finishing
normally and collecting logs. Add timeouts.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
