### PR TITLE
:seedling: Add periodic jobs for release-0.10 and 0.11

### DIFF
--- a/.github/workflows/functional-periodic-release-0.10.yml
+++ b/.github/workflows/functional-periodic-release-0.10.yml
@@ -2,8 +2,8 @@ name: Periodic Functional Tests release-0.10
 
 on:
   schedule:
-  # Run every day at 03:25 UTC (it is recommended to avoid running at the start of the hour)
-  - cron: '25 3 * * *'
+  # Run every day at 05:20 UTC (it is recommended to avoid running at the start of the hour)
+  - cron: '20 5 * * *'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/functional-periodic-release-0.10.yml
+++ b/.github/workflows/functional-periodic-release-0.10.yml
@@ -1,9 +1,9 @@
-name: Periodic Functional Tests release-0.8
+name: Periodic Functional Tests release-0.10
 
 on:
   schedule:
-  # Run every day at 04:20 UTC (it is recommended to avoid running at the start of the hour)
-  - cron: '20 4 * * *'
+  # Run every day at 03:25 UTC (it is recommended to avoid running at the start of the hour)
+  - cron: '25 3 * * *'
   workflow_dispatch:
 
 permissions: {}
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'metal3-io/ironic-standalone-operator'
     uses: ./.github/workflows/functional.yml
     with:
-      ref: release-0.8
+      ref: release-0.10
       fail-fast: false
     permissions:
       checks: write

--- a/.github/workflows/functional-periodic-release-0.11.yml
+++ b/.github/workflows/functional-periodic-release-0.11.yml
@@ -2,8 +2,8 @@ name: Periodic Functional Tests release-0.11
 
 on:
   schedule:
-  # Run every day at 03:30 UTC (it is recommended to avoid running at the start of the hour)
-  - cron: '30 3 * * *'
+  # Run every day at 04:20 UTC (it is recommended to avoid running at the start of the hour)
+  - cron: '20 4 * * *'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/functional-periodic-release-0.11.yml
+++ b/.github/workflows/functional-periodic-release-0.11.yml
@@ -1,9 +1,9 @@
-name: Periodic Functional Tests release-0.7
+name: Periodic Functional Tests release-0.11
 
 on:
   schedule:
-  # Run every day at 05:20 UTC (it is recommended to avoid running at the start of the hour)
-  - cron: '20 5 * * *'
+  # Run every day at 03:30 UTC (it is recommended to avoid running at the start of the hour)
+  - cron: '30 3 * * *'
   workflow_dispatch:
 
 permissions: {}
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'metal3-io/ironic-standalone-operator'
     uses: ./.github/workflows/functional.yml
     with:
-      ref: release-0.7
+      ref: release-0.11
       fail-fast: false
     permissions:
       checks: write


### PR DESCRIPTION
Fixes #841

Adds periodic functional workflows for `release-0.10` and `release-0.11` (modeled on the existing `release-0.9` job), with cron schedules offset by a few minutes. Also removes the obsolete `release-0.7` and `release-0.8` periodic workflows, which are no longer supported per the version support policy.