### PR TITLE
🌱 Bump image container to 0.14.19

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -12,3 +12,7 @@ config:
 
 # Don't autofix anything, we're linting here
 fix: false
+
+# CLAUDE.md is a pointer file for AI tooling, not prose documentation
+ignores:
+- "CLAUDE.md"

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -15,6 +15,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0 \
+        docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa \
         /workdir/hack/markdownlint.sh "$@"
 fi


### PR DESCRIPTION
Bump the pinned markdownlint-cli2 container image from to 0.14.19

Part of https://github.com/metal3-io/project-infra/issues/1531