### PR TITLE
:seedling: Fix yamllint workflow

### DIFF
--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -10,7 +10,6 @@ on:
 jobs:
   yamllint-check:
     name: yaml-lint
-    timeout-minutes: 5
     uses: metal3-io/project-infra/.github/workflows/yamllint.yaml@main # zizmor: ignore[unpinned-uses]
     with:
       ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The keyword 'timeout-minutes' is not allowed with 'uses' and causes a parsing error.