### PR TITLE
📖 Document periodic functional workflow maintenance

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -203,6 +203,22 @@ don't allow major or minor bumps in release branches.
 
 [Prior art](https://github.com/metal3-io/ironic-standalone-operator/pull/295)
 
+### Periodic functional test workflows
+
+Periodic functional test workflows must exist for every release branch that
+is currently `Supported` or `Tested`, per the [version support
+policy](https://book.metal3.io/version_support.html#ironic-standalone-operator).
+
+For a new release branch, copy an existing
+`.github/workflows/functional-periodic-release-X.Y.yml`, rename it for the
+new branch, and update the workflow `name`, the `ref` under `with:`, and the
+`cron` schedule so it doesn't collide with the other periodic runs.
+
+Release branches that are End-of-Life should have their periodic workflow
+removed in the same PR.
+
+[Prior art](https://github.com/metal3-io/ironic-standalone-operator/pull/843)
+
 ### Branch protection rules
 
 Branch protection rules need to be applied to the new release branch. Copy the


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a subsection to `releasing.md` explaining that periodic functional test workflows must be added for every new release branch that is Supported or Tested, and removed once a branch is EOL. This is modeled on the existing Dependabot configuration section.

The workflow drift itself was already fixed in #843, but that PR didn't include the documentation the original issue asked for — this closes that remaining gap.

Fixes #842

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.